### PR TITLE
fix(ai): voice expense entry regression — revert whisper + parseExpense to gpt-4o

### DIFF
--- a/apps/api/src/modules/ai/services/categorization.service.ts
+++ b/apps/api/src/modules/ai/services/categorization.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { PrismaService } from '../../../database/prisma.service';
-import { resolveCheapModel } from './model-resolver';
+import { resolveAiModel, resolveCheapModel } from './model-resolver';
 import { sanitizeForPrompt } from '../utils/sanitize';
 import { EmbeddingService } from './embedding.service';
 
@@ -89,9 +89,15 @@ export class CategorizationService {
   }
 
   async parseExpenseFromText(text: string, userId: string, accountId: string) {
-    // Cheap model: this is a one-shot JSON extraction, no reasoning required.
-    void userId;
-    const aiModel = resolveCheapModel();
+    // Free-form natural-language extraction (amount + currency + description
+    // + category + merchant from short voice/text input). Empirically the
+    // cheap model loses fidelity on short multilingual transcripts — keep
+    // honoring the user's aiModel preference (gpt-4o by default).
+    const userPref = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { aiModel: true },
+    });
+    const { model: aiModel } = resolveAiModel(userPref?.aiModel);
 
     // Try history-based suggestion first (fast, free)
     const historySuggestion = await this.suggestFromHistory(accountId, text);

--- a/apps/api/src/modules/ai/services/whisper.service.ts
+++ b/apps/api/src/modules/ai/services/whisper.service.ts
@@ -1,12 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
-import { trimSilence, probeDuration } from '../utils/audio-trim';
 
 @Injectable()
 export class WhisperService {
   private readonly openai: OpenAI;
-  private readonly logger = new Logger(WhisperService.name);
 
   constructor(private readonly configService: ConfigService) {
     this.openai = new OpenAI({
@@ -14,67 +12,45 @@ export class WhisperService {
     });
   }
 
-  async transcribe(
-    audioBuffer: Buffer,
-    language?: string,
-    mimeType?: string,
-  ): Promise<{ text: string; language: string; duration: number; trimmedSec: number }> {
+  async transcribe(audioBuffer: Buffer, language?: string, mimeType?: string): Promise<{ text: string; language: string; duration: number }> {
+    // Detect format from buffer magic bytes or use provided mimeType
     const detectedMime = mimeType || this.detectMimeType(audioBuffer);
     const ext = this.mimeToExt(detectedMime);
 
-    // Trim leading/trailing silence so we don't pay for empty seconds.
-    // gpt-4o-mini-transcribe bills per second of audio; silence costs the same
-    // as speech.
-    let bufferToSend = audioBuffer;
-    let durationSec = 0;
-    let trimmedSec = 0;
-    try {
-      const trimmed = await trimSilence(audioBuffer, detectedMime);
-      bufferToSend = trimmed.buffer;
-      durationSec = trimmed.outputDuration;
-      trimmedSec = trimmed.trimmedSec;
-    } catch (err) {
-      this.logger.warn(`silence trim failed, using raw buffer: ${(err as Error).message}`);
-      durationSec = await probeDuration(audioBuffer, detectedMime).catch(() => 0);
-    }
-
-    const arrayBuffer = bufferToSend.buffer.slice(
-      bufferToSend.byteOffset,
-      bufferToSend.byteOffset + bufferToSend.byteLength,
+    const arrayBuffer = audioBuffer.buffer.slice(
+      audioBuffer.byteOffset,
+      audioBuffer.byteOffset + audioBuffer.byteLength,
     ) as ArrayBuffer;
     const blob = new Blob([arrayBuffer], { type: detectedMime });
     const file = new File([blob], `audio.${ext}`, { type: detectedMime });
 
     const response = await this.openai.audio.transcriptions.create({
       file,
-      // gpt-4o-mini-transcribe is ~50% cheaper per minute than whisper-1.
-      // It supports response_format 'json' or 'text' only — no verbose_json,
-      // so duration and detected language are not returned. Duration comes
-      // from ffprobe above; language is whatever the caller passes (or 'en').
-      model: 'gpt-4o-mini-transcribe',
+      model: 'whisper-1',
       language: language || undefined,
-      response_format: 'json',
+      response_format: 'verbose_json',
     });
-
-    this.logger.log(
-      `duration=${durationSec.toFixed(2)}s trimmed=${trimmedSec.toFixed(2)}s text_len=${response.text.length}`,
-    );
 
     return {
       text: response.text,
-      language: language || 'en',
-      duration: durationSec,
-      trimmedSec,
+      language: response.language || language || 'en',
+      duration: response.duration || 0,
     };
   }
 
   private detectMimeType(buffer: Buffer): string {
     if (buffer.length < 12) return 'audio/m4a';
+    // ftyp box = MP4/M4A container
     if (buffer.slice(4, 8).toString() === 'ftyp') return 'audio/m4a';
+    // RIFF = WAV
     if (buffer.slice(0, 4).toString() === 'RIFF') return 'audio/wav';
+    // OggS = OGG
     if (buffer.slice(0, 4).toString() === 'OggS') return 'audio/ogg';
+    // webm/matroska
     if (buffer[0] === 0x1a && buffer[1] === 0x45 && buffer[2] === 0xdf && buffer[3] === 0xa3) return 'audio/webm';
+    // ID3 or sync bits = MP3
     if (buffer.slice(0, 3).toString() === 'ID3' || (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0)) return 'audio/mpeg';
+    // fLaC
     if (buffer.slice(0, 4).toString() === 'fLaC') return 'audio/flac';
     return 'audio/m4a';
   }


### PR DESCRIPTION
## Root cause

PR #80 broke voice expense entry in two places:

1. **`parseExpenseFromText` was switched to `gpt-4o-mini`** — the cheap model loses too much fidelity on short Russian/Ukrainian voice transcripts. Mobile renders the form with amount=0 and empty description, which looks like \"nothing got filled in\" to the user. Confirmed via prod nginx access logs: parse-expense responses dropped from typical ~400+ bytes to 139–215 bytes. **(commit \`53d44e1\`)**

2. **`whisper.service.ts` was switched to `gpt-4o-mini-transcribe` + ffmpeg silence trim** — kept the revert from yesterday's hotfix as a conservative belt-and-suspenders measure. Whisper logs show transcription was actually working (text_len=22 in logs from 17:49:50), so this layer wasn't the failing one — but I'd rather revert both together and re-introduce one at a time with telemetry. **(commit \`c2a0a68\`)**

## What's restored

- \`apps/api/src/modules/ai/services/whisper.service.ts\` → pre-#80 (whisper-1 + verbose_json, no silence trim)
- \`apps/api/src/modules/ai/services/categorization.service.ts:parseExpenseFromText\` → resolves user's \`aiModel\` preference (gpt-4o by default)

## What stays from #80 (still saves cost, doesn't touch voice)

- Prompt-cache restructure on chat
- \`gpt-4o-mini\` for chat confirmation + read-tool follow-up
- \`gpt-4o-mini\` for **`categorize`** (single-field classification — safe), tag, split, project
- Embedding shortcut (currently inactive until rows are backfilled)
- Redis cache for chat read-tool queries

## What's left in repo for later

- \`apps/api/src/modules/ai/utils/audio-trim.ts\` and tests (unused)
- ffmpeg in Dockerfile (unused, harmless ~30MB)

## Diagnosis evidence

Prod nginx log (\`17:49:55\`): \`POST /api/v1/ai/parse-expense → 201, 215 bytes\` — typical healthy response is ~400+ bytes including categoryId, categorySuggestion, merchant. 215 bytes ≈ \`{\"amount\":0,\"currencyCode\":\"USD\",\"description\":\"\",...}\`.

Prod whisper log: \`[WhisperService] duration=2.30s trimmed=4.41s text_len=22\` — transcription itself succeeded.

## Test plan

- [x] \`npm run typecheck\` (api)
- [x] \`npm run lint\` (api, all changed files)
- [ ] Post-deploy: voice expense entry produces a populated form (amount, description, category)
- [ ] Confirm with reporter that voice works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)