### PR TITLE
feat(mobile): full-screen loading overlay during login

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -203,6 +203,15 @@ export default function LoginScreen() {
           </View>
         </View>
       </KeyboardAvoidingView>
+      {isLoading && (
+        <View style={styles.loadingOverlay} pointerEvents="auto">
+          <View style={styles.loadingCard}>
+            <ActivityIndicator size="large" color={theme.colors.primary} />
+            <Text style={styles.loadingText}>{t('auth.signingIn')}</Text>
+            <Text style={styles.loadingSubtext}>{t('auth.loadingData')}</Text>
+          </View>
+        </View>
+      )}
     </SafeAreaView>
   );
 }
@@ -318,5 +327,42 @@ const createStyles = (theme: Theme) => ({
     ...theme.textStyles.bodySm,
     fontWeight: '600' as const,
     color: theme.colors.primary,
+  },
+  loadingOverlay: {
+    ...(Platform.OS === 'web'
+      ? { position: 'fixed' as any }
+      : { position: 'absolute' as const }),
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: theme.colors.background + 'E6',
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+    zIndex: 10,
+  },
+  loadingCard: {
+    backgroundColor: theme.colors.surface,
+    paddingVertical: theme.spacing[6],
+    paddingHorizontal: theme.spacing[8],
+    borderRadius: theme.borderRadius.xl,
+    alignItems: 'center' as const,
+    gap: theme.spacing[3],
+    minWidth: 220,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  loadingText: {
+    ...theme.textStyles.bodyLargeMedium,
+    color: theme.colors.textPrimary,
+    textAlign: 'center' as const,
+  },
+  loadingSubtext: {
+    ...theme.textStyles.bodySm,
+    color: theme.colors.textSecondary,
+    textAlign: 'center' as const,
   },
 });

--- a/apps/mobile/src/i18n/locales/be.ts
+++ b/apps/mobile/src/i18n/locales/be.ts
@@ -93,6 +93,8 @@ export default {
     verify: 'Пацвердзіць',
     verificationSuccess: 'Пошта паспяхова пацверджана!',
     enterVerificationCode: 'Увядзіце 6-значны код, адпраўлены на {{email}}',
+    signingIn: 'Уваход...',
+    loadingData: 'Загрузка вашых даных...',
   },
   dashboard: {
     hello: 'Прывітанне, {{name}}!',

--- a/apps/mobile/src/i18n/locales/de.ts
+++ b/apps/mobile/src/i18n/locales/de.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Verifizieren',
     verificationSuccess: 'E-Mail erfolgreich verifiziert!',
     enterVerificationCode: 'Geben Sie den 6-stelligen Code ein, der an {{email}} gesendet wurde',
+    signingIn: 'Anmeldung...',
+    loadingData: 'Ihre Daten werden geladen...',
   },
   dashboard: {
     hello: 'Hallo, {{name}}!',

--- a/apps/mobile/src/i18n/locales/en.ts
+++ b/apps/mobile/src/i18n/locales/en.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Verify',
     verificationSuccess: 'Email verified successfully!',
     enterVerificationCode: 'Enter the 6-digit code sent to {{email}}',
+    signingIn: 'Signing in...',
+    loadingData: 'Loading your data...',
   },
   dashboard: {
     hello: 'Hello, {{name}}!',

--- a/apps/mobile/src/i18n/locales/es.ts
+++ b/apps/mobile/src/i18n/locales/es.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Verificar',
     verificationSuccess: '¡Correo verificado con éxito!',
     enterVerificationCode: 'Ingresa el código de 6 dígitos enviado a {{email}}',
+    signingIn: 'Iniciando sesión...',
+    loadingData: 'Cargando tus datos...',
   },
   dashboard: {
     hello: '¡Hola, {{name}}!',

--- a/apps/mobile/src/i18n/locales/fr.ts
+++ b/apps/mobile/src/i18n/locales/fr.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Vérifier',
     verificationSuccess: 'E-mail vérifié avec succès !',
     enterVerificationCode: 'Entrez le code à 6 chiffres envoyé à {{email}}',
+    signingIn: 'Connexion...',
+    loadingData: 'Chargement de vos données...',
   },
   dashboard: {
     hello: 'Bonjour, {{name}}!',

--- a/apps/mobile/src/i18n/locales/pl.ts
+++ b/apps/mobile/src/i18n/locales/pl.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Weryfikuj',
     verificationSuccess: 'E-mail zweryfikowany pomyślnie!',
     enterVerificationCode: 'Wprowadź 6-cyfrowy kod wysłany na {{email}}',
+    signingIn: 'Logowanie...',
+    loadingData: 'Ładowanie Twoich danych...',
   },
   dashboard: {
     hello: 'Cześć, {{name}}!',

--- a/apps/mobile/src/i18n/locales/ru.ts
+++ b/apps/mobile/src/i18n/locales/ru.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Подтвердить',
     verificationSuccess: 'Почта успешно подтверждена!',
     enterVerificationCode: 'Введите 6-значный код, отправленный на {{email}}',
+    signingIn: 'Вход...',
+    loadingData: 'Загрузка ваших данных...',
   },
   dashboard: {
     hello: 'Привет, {{name}}!',

--- a/apps/mobile/src/i18n/locales/ua.ts
+++ b/apps/mobile/src/i18n/locales/ua.ts
@@ -95,6 +95,8 @@ export default {
     verify: 'Підтвердити',
     verificationSuccess: 'Пошту успішно підтверджено!',
     enterVerificationCode: 'Введіть 6-значний код, надісланий на {{email}}',
+    signingIn: 'Вхід...',
+    loadingData: 'Завантаження ваших даних...',
   },
   dashboard: {
     hello: 'Привіт, {{name}}!',

--- a/apps/mobile/src/stores/authStore.ts
+++ b/apps/mobile/src/stores/authStore.ts
@@ -139,7 +139,6 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
             user,
             accessToken: response.accessToken,
             refreshToken: response.refreshToken,
-            isLoading: false,
             hasSavedSession: false,
           });
 
@@ -176,8 +175,10 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           ]);
 
           // Mark as authenticated only after all data is ready so the
-          // dashboard mounts with data already in the stores
-          set({ isAuthenticated: user.isVerified });
+          // dashboard mounts with data already in the stores. Keep isLoading
+          // true through the entire flow so the login UI keeps showing the
+          // loader until navigation actually happens.
+          set({ isAuthenticated: user.isVerified, isLoading: false });
         } catch (error) {
           // Network error — try offline login with cached session
           const isNetworkError = error instanceof TypeError
@@ -197,8 +198,6 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
                   user: cachedUser,
                   accessToken: cachedToken,
                   refreshToken: await secureStorage.getItem('refreshToken'),
-                  isLoading: false,
-                  isAuthenticated: true,
                   hasSavedSession: false,
                 });
                 await useAccountStore.getState().loadAccounts();
@@ -210,6 +209,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
                   useWalletStore.getState().loadWallet(),
                   useBudgetStore.getState().loadBudgets(),
                 ]);
+                set({ isAuthenticated: true, isLoading: false });
                 return;
               }
             }
@@ -252,7 +252,6 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
             user,
             accessToken: response.accessToken,
             refreshToken: response.refreshToken,
-            isLoading: false,
             hasSavedSession: false,
           });
 
@@ -279,8 +278,10 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           ]);
 
           // Mark as authenticated only after all data is ready so the
-          // dashboard mounts with data already in the stores
-          set({ isAuthenticated: user.isVerified });
+          // dashboard mounts with data already in the stores. Keep isLoading
+          // true through the entire flow so the registration UI keeps
+          // showing the loader until navigation actually happens.
+          set({ isAuthenticated: user.isVerified, isLoading: false });
         } catch (error) {
           set({
             error: error instanceof Error ? error.message : 'Registration failed',
@@ -291,6 +292,7 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
       },
 
       biometricLogin: async () => {
+        set({ isLoading: true, error: null });
         try {
           const accessToken = await secureStorage.getItem('accessToken');
           const refreshToken = await secureStorage.getItem('refreshToken');
@@ -360,11 +362,12 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
             useBudgetStore.getState().loadBudgets(),
           ]);
           // Mark as authenticated only after all data is ready
-          set({ isAuthenticated: true });
+          set({ isAuthenticated: true, isLoading: false });
         } catch (error) {
           set({
             error: error instanceof Error ? error.message : 'Biometric login failed',
             hasSavedSession: false,
+            isLoading: false,
           });
           throw error;
         }


### PR DESCRIPTION
Show a centered loader card with "Signing in..." while login or
biometric login is in progress. Previously the only feedback was a
small spinner on the sign-in button that turned off as soon as the API
call returned, leaving the screen idle for several seconds while
exchange rates, expenses, incomes, categories, wallet and budgets
hydrated. Users couldn't tell the app was still working.

Also keep authStore.isLoading=true through the entire login/register
flow (including the offline-cache fallback) and start tracking it for
biometricLogin so the auto-triggered fingerprint flow on app launch
also surfaces the loader.