### PR TITLE
perf(mobile): freeze inactive tabs and defer on-focus loads to fix tab-switch lag

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -29,6 +29,10 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
+        // Freeze inactive tabs so unrelated store updates don't re-render
+        // background screens — keeps the tab-switch animation on the UI thread.
+        freezeOnBlur: true,
+        lazy: true,
         tabBarActiveTintColor: theme.colors.tabBarActive,
         tabBarInactiveTintColor: theme.colors.tabBarInactive,
         tabBarStyle: {

--- a/apps/mobile/app/(tabs)/analytics.tsx
+++ b/apps/mobile/app/(tabs)/analytics.tsx
@@ -1,4 +1,4 @@
-import { View, Text, ScrollView, TouchableOpacity, LayoutAnimation, Platform, UIManager } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, LayoutAnimation, Platform, UIManager, InteractionManager } from 'react-native';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -59,12 +59,16 @@ export default function AnalyticsScreen() {
 
   // Make sure expenses/incomes are hydrated even if the user lands on Analytics
   // first. Stores are local-first (SQLite immediately, API in background).
+  // Deferred via InteractionManager so the on-focus reload runs after the
+  // tab-switch animation completes.
   useFocusEffect(
     useCallback(() => {
-      if (currentAccountId) {
+      if (!currentAccountId) return;
+      const handle = InteractionManager.runAfterInteractions(() => {
         loadExpenses();
         loadIncomes();
-      }
+      });
+      return () => handle.cancel();
     }, [currentAccountId, loadExpenses, loadIncomes]),
   );
 

--- a/apps/mobile/app/(tabs)/budgets.tsx
+++ b/apps/mobile/app/(tabs)/budgets.tsx
@@ -1,4 +1,4 @@
-import { View, Text, FlatList, TouchableOpacity, RefreshControl, ActivityIndicator } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, RefreshControl, ActivityIndicator, InteractionManager } from 'react-native';
 import { useState, useCallback, useEffect } from 'react';
 import { router, useFocusEffect } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -26,9 +26,15 @@ export default function BudgetsScreen() {
     if (currentAccountId) loadBudgets();
   }, [currentAccountId, loadBudgets]);
 
+  // Defer the on-focus refresh until after the tab transition so it doesn't
+  // block the animation frame.
   useFocusEffect(
     useCallback(() => {
-      if (currentAccountId) loadBudgets();
+      if (!currentAccountId) return;
+      const handle = InteractionManager.runAfterInteractions(() => {
+        loadBudgets();
+      });
+      return () => handle.cancel();
     }, [currentAccountId, loadBudgets]),
   );
 

--- a/apps/mobile/app/(tabs)/expenses.tsx
+++ b/apps/mobile/app/(tabs)/expenses.tsx
@@ -1,4 +1,4 @@
-import { View, Text, FlatList, TouchableOpacity, RefreshControl, Animated, ScrollView, Image, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, RefreshControl, Animated, ScrollView, Image, Alert, ActivityIndicator, InteractionManager } from 'react-native';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { router, useLocalSearchParams, useFocusEffect } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -68,12 +68,16 @@ export default function ExpensesScreen() {
   }, [currentAccountId, loadExpenses, loadIncomes]);
 
   // Refresh when tab regains focus (cheap: SQLite read first, API in background).
+  // Deferred via InteractionManager so the heavy reload work runs after the
+  // tab-switch animation completes.
   useFocusEffect(
     useCallback(() => {
-      if (currentAccountId) {
+      if (!currentAccountId) return;
+      const handle = InteractionManager.runAfterInteractions(() => {
         loadExpenses();
         loadIncomes();
-      }
+      });
+      return () => handle.cancel();
     }, [currentAccountId, loadExpenses, loadIncomes]),
   );
 

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
-import { View, Text, ScrollView, TouchableOpacity, RefreshControl, Image } from 'react-native';
-import { useState, useCallback, useEffect } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, RefreshControl, Image, InteractionManager } from 'react-native';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { router, useFocusEffect } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -55,11 +55,17 @@ export default function DashboardScreen() {
 
   const currency = user?.currencyCode || 'USD';
 
-  const convertedLentTotal = lentDebts.reduce(
-    (sum, d) => sum + convertAmount(d.remainingAmount, d.currencyCode, currency, rates), 0,
+  const convertedLentTotal = useMemo(
+    () => lentDebts.reduce(
+      (sum, d) => sum + convertAmount(d.remainingAmount, d.currencyCode, currency, rates), 0,
+    ),
+    [lentDebts, currency, rates],
   );
-  const convertedBorrowedTotal = borrowedDebts.reduce(
-    (sum, d) => sum + convertAmount(d.remainingAmount, d.currencyCode, currency, rates), 0,
+  const convertedBorrowedTotal = useMemo(
+    () => borrowedDebts.reduce(
+      (sum, d) => sum + convertAmount(d.remainingAmount, d.currencyCode, currency, rates), 0,
+    ),
+    [borrowedDebts, currency, rates],
   );
 
   useEffect(() => {
@@ -72,11 +78,15 @@ export default function DashboardScreen() {
     }
   }, [currentAccountId, loadExpenses, loadIncomes, loadProfile, loadDebts, currentAccountType, loadInvestmentSummary]);
 
+  // Defer the on-focus refresh until after the tab transition finishes so it
+  // doesn't block the animation frame.
   useFocusEffect(
     useCallback(() => {
-      if (currentAccountId) {
+      if (!currentAccountId) return;
+      const handle = InteractionManager.runAfterInteractions(() => {
         Promise.all([loadExpenses(), loadIncomes()]).then(() => loadDebts());
-      }
+      });
+      return () => handle.cancel();
     }, [currentAccountId, loadExpenses, loadIncomes, loadDebts]),
   );
 

--- a/apps/mobile/src/features/analytics/useAnalytics.ts
+++ b/apps/mobile/src/features/analytics/useAnalytics.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { InteractionManager } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useExpenseStore } from '@/stores/expenseStore';
 import { useBudgetStore } from '@/stores/budgetStore';
@@ -491,16 +492,18 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
   const [itemBreakdown, setItemBreakdown] = useState<ItemBreakdown[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
     const computeItemBreakdown = async () => {
       const ocrExpenses = filteredExpenses.filter((e) => e.source === 'ocr');
       if (ocrExpenses.length === 0) {
-        setItemBreakdown([]);
+        if (!cancelled) setItemBreakdown([]);
         return;
       }
 
       const itemMap = new Map<string, { totalSpent: number; count: number }>();
 
       for (const expense of ocrExpenses) {
+        if (cancelled) return;
         try {
           const items = await loadItemsByExpenseId(expense.id);
           for (const item of items) {
@@ -517,6 +520,7 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
         }
       }
 
+      if (cancelled) return;
       const result: ItemBreakdown[] = Array.from(itemMap.entries())
         .map(([description, data]) => ({
           description,
@@ -530,27 +534,37 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
       setItemBreakdown(result);
     };
 
-    computeItemBreakdown();
+    // Defer until after the tab transition / first paint so the JS thread is
+    // free for the navigation animation. Cancellable on unmount or dep change.
+    const handle = InteractionManager.runAfterInteractions(() => {
+      if (!cancelled) computeItemBreakdown();
+    });
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
   }, [filteredExpenses, toDisplayCurrency]);
 
   // Tag spending breakdown
   const [tagSpending, setTagSpending] = useState<TagSpending[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
     const computeTagSpending = async () => {
       if (filteredExpenses.length === 0) {
-        setTagSpending([]);
+        if (!cancelled) setTagSpending([]);
         return;
       }
 
       const accountId = useAccountStore.getState().currentAccountId;
       if (!accountId) {
-        setTagSpending([]);
+        if (!cancelled) setTagSpending([]);
         return;
       }
 
       try {
         const mappings = await getAllExpenseTagMappings(accountId);
+        if (cancelled) return;
         const expenseIds = new Set(filteredExpenses.map(e => e.id));
         const expenseAmountMap = new Map(filteredExpenses.map(e => [e.id, getAmount(e)]));
 
@@ -564,7 +578,7 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
 
         const totalTagged = Array.from(tagAmountMap.values()).reduce((s, a) => s + a, 0);
         if (totalTagged === 0) {
-          setTagSpending([]);
+          if (!cancelled) setTagSpending([]);
           return;
         }
 
@@ -582,33 +596,41 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
           colorIndex++;
         }
 
-        setTagSpending(result.sort((a, b) => b.amount - a.amount));
+        if (!cancelled) setTagSpending(result.sort((a, b) => b.amount - a.amount));
       } catch {
-        setTagSpending([]);
+        if (!cancelled) setTagSpending([]);
       }
     };
 
-    computeTagSpending();
+    const handle = InteractionManager.runAfterInteractions(() => {
+      if (!cancelled) computeTagSpending();
+    });
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
   }, [filteredExpenses, tags, getAmount]);
 
   // Project spending breakdown
   const [projectSpending, setProjectSpending] = useState<ProjectSpending[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
     const computeProjectSpending = async () => {
       if (filteredExpenses.length === 0) {
-        setProjectSpending([]);
+        if (!cancelled) setProjectSpending([]);
         return;
       }
 
       const accountId = useAccountStore.getState().currentAccountId;
       if (!accountId) {
-        setProjectSpending([]);
+        if (!cancelled) setProjectSpending([]);
         return;
       }
 
       try {
         const mappings = await getAllProjectExpenseMappings(accountId);
+        if (cancelled) return;
         const expenseIds = new Set(filteredExpenses.map(e => e.id));
         const expenseAmountMap = new Map(filteredExpenses.map(e => [e.id, getAmount(e)]));
 
@@ -622,7 +644,7 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
 
         const totalProjected = Array.from(projectAmountMap.values()).reduce((s, a) => s + a, 0);
         if (totalProjected === 0) {
-          setProjectSpending([]);
+          if (!cancelled) setProjectSpending([]);
           return;
         }
 
@@ -641,13 +663,19 @@ export function useAnalytics(timeRange: TimeRange = 'month', currencyCode?: stri
           colorIndex++;
         }
 
-        setProjectSpending(result.sort((a, b) => b.amount - a.amount));
+        if (!cancelled) setProjectSpending(result.sort((a, b) => b.amount - a.amount));
       } catch {
-        setProjectSpending([]);
+        if (!cancelled) setProjectSpending([]);
       }
     };
 
-    computeProjectSpending();
+    const handle = InteractionManager.runAfterInteractions(() => {
+      if (!cancelled) computeProjectSpending();
+    });
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
   }, [filteredExpenses, projects, getAmount]);
 
   return {


### PR DESCRIPTION
The previous "local-first hydration" change cut the network wait on tab
focus, but the heavy SQLite reads + sync work still ran inline on every
focus and re-rendered every tab that subscribes to the same store. The
animation frame for the bottom-tab transition was getting starved.

- Tabs: freezeOnBlur + lazy so background tabs stop re-rendering on store
  updates from the foreground tab.
- index/expenses/budgets/analytics: wrap useFocusEffect loads in
  InteractionManager.runAfterInteractions so the reload runs after the
  tab transition finishes, with cleanup to cancel on unmount.
- index: memoize convertedLentTotal/convertedBorrowedTotal — they were
  reduce()-ing the debts list on every render.
- useAnalytics: defer the 3 SQLite-backed breakdowns (item / tag /
  project) via InteractionManager and add a cancellation flag so a fast
  tab swap doesn't leave stale work in flight.