### PR TITLE
fix(mobile): force fresh version check on app resume so update prompt closes after update

### DIFF
--- a/apps/mobile/src/hooks/useAppVersionCheck.ts
+++ b/apps/mobile/src/hooks/useAppVersionCheck.ts
@@ -24,8 +24,8 @@ export function useAppVersionCheck(): State {
   useEffect(() => {
     if (Platform.OS === 'web') return;
 
-    async function run() {
-      if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    async function run(opts?: { force?: boolean }) {
+      if (!opts?.force && cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
         setState(cached.state);
         return;
       }
@@ -54,7 +54,7 @@ export function useAppVersionCheck(): State {
 
     run();
     const sub = AppState.addEventListener('change', (s: AppStateStatus) => {
-      if (s === 'active') run();
+      if (s === 'active') run({ force: true });
     });
     return () => {
       sub.remove();


### PR DESCRIPTION
The 6h cache prevented the AppState 'active' handler from re-fetching, so
returning from the store after updating left the modal visible.

https://claude.ai/code/session_01JQ8GX8AZqpudHAftafQ4QB