### PR TITLE
Fix accounts not loading after web login

### DIFF
--- a/apps/mobile/src/db/client.web.ts
+++ b/apps/mobile/src/db/client.web.ts
@@ -46,6 +46,22 @@ export const db = {
   }),
 };
 
+export type QueryResult<T = Record<string, unknown>> = T[];
+
+// Raw-SQL escape hatch used by the repositories. expo-sqlite has no web
+// backend, so this is a no-op that always resolves to an empty result set.
+// IMPORTANT: this MUST be exported here — repositories import `executeSql`
+// from `./client`, which Metro resolves to this file on web. If it is missing,
+// the import is `undefined` and every repository call throws at runtime
+// (e.g. accounts never load after login on https://ai-budget.pl). Stores are
+// expected to fall back to the API response when this returns no rows.
+export function executeSql<T = Record<string, unknown>>(
+  _sql: string,
+  _params?: (string | number | null)[],
+): Promise<QueryResult<T>> {
+  return Promise.resolve([]);
+}
+
 // Database initialization
 export async function initializeDatabase(): Promise<void> {
   // web mock — no-op

--- a/apps/mobile/src/stores/accountStore.ts
+++ b/apps/mobile/src/stores/accountStore.ts
@@ -66,6 +66,24 @@ async function getCurrentUserId(): Promise<string | null> {
   }
 }
 
+// Normalize a server account payload into the in-memory shape the store uses.
+// Used as a fallback when the local SQLite read-back returns no rows — notably
+// on web, where SQLite is a no-op mock, so the round-trip through the local DB
+// would otherwise drop the accounts the API just returned.
+function toAccountWithRole(
+  account: Account & { myRole?: AccountRole },
+  userId: string | null,
+): Account & { myRole: AccountRole } {
+  const myRole: AccountRole =
+    account.myRole ?? (userId && account.ownerId === userId ? 'owner' : 'editor');
+  return {
+    ...account,
+    myRole,
+    createdAt: account.createdAt ? new Date(account.createdAt) : new Date(),
+    updatedAt: account.updatedAt ? new Date(account.updatedAt) : new Date(),
+  };
+}
+
 export const useAccountStore = create<AccountState>()((set, get) => ({
   accounts: [],
   currentAccountId: null,
@@ -84,7 +102,15 @@ export const useAccountStore = create<AccountState>()((set, get) => ({
       await insertAccounts(serverAccounts as (Account & { myRole?: AccountRole })[], userId);
 
       // Load from local DB to get consistent format with myRole (filtered by userId)
-      const localAccounts = await loadAllAccounts(userId);
+      let localAccounts = await loadAllAccounts(userId);
+
+      // Web (no real SQLite) returns nothing from the read-back — fall back to
+      // the server payload so the accounts the API returned are still shown.
+      if (localAccounts.length === 0 && serverAccounts.length > 0) {
+        localAccounts = serverAccounts.map((a) =>
+          toAccountWithRole(a as Account & { myRole?: AccountRole }, userId),
+        );
+      }
 
       const currentId = defaultAccountId || localAccounts[0]?.id || null;
 
@@ -147,7 +173,16 @@ export const useAccountStore = create<AccountState>()((set, get) => ({
         await insertAccounts(serverAccounts, userId);
       }
 
-      const localAccounts = await loadAllAccounts(userId ?? undefined);
+      let localAccounts = await loadAllAccounts(userId ?? undefined);
+
+      // Web (no real SQLite) returns nothing from the read-back — fall back to
+      // the server payload so the accounts the API returned are still shown.
+      if (localAccounts.length === 0 && serverAccounts.length > 0) {
+        localAccounts = serverAccounts.map((a) =>
+          toAccountWithRole(a as Account & { myRole?: AccountRole }, userId),
+        );
+      }
+
       const { currentAccountId } = get();
 
       set({


### PR DESCRIPTION
On web, SQLite is a no-op mock and executeSql was missing entirely from
client.web.ts, so every repository call threw at runtime. The account
store inserts accounts into SQLite then reads them back, so after login
via https://ai-budget.pl the read-back returned nothing (or threw) and
no accounts were shown.

- Add the missing executeSql (and QueryResult type) export to
  client.web.ts so web repository calls resolve to a no-op instead of
  throwing.
- In accountStore.initialize and loadAccountsFromServer, fall back to the
  server account payload when the local read-back is empty, via a new
  toAccountWithRole normalizer. This restores account visibility on web
  while keeping the offline-first SQLite path unchanged on native.

https://claude.ai/code/session_01YbXanDG36iK3uw4eRnuLTU