### PR TITLE
Fix web login: missing accounts + doubled-domain deep-link path

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -113,7 +113,12 @@ function RootNavigator() {
 
   useEffect(() => {
     if (isInitializing || !isAuthenticated) return;
-
+    // Web: the browser URL is already the route and Expo Router handles it
+    // natively. Running the custom-scheme deep-link logic here would treat the
+    // domain as a path segment (budget://expense/voice puts the first segment
+    // in URL.host), turning https://ai-budget.pl/expenses into a push to
+    // "/ai-budget.pl/expenses" → https://ai-budget.pl/ai-budget.pl/expenses.
+    if (Platform.OS === 'web') return;
     function navigateToDeepLink(url: string) {
       // Subscription deep links are handled by WebBrowser.openAuthSessionAsync — ignore here
       if (url.includes('subscription/success') || url.includes('subscription/cancel')) return;
@@ -128,10 +133,17 @@ function RootNavigator() {
       let fullPath: string | null = null;
       try {
         const parsed = new URL(url);
-        const path = parsed.pathname || parsed.host;
-        if (path && path !== '/') {
-          // Normalize: budget://expense/voice has host="expense", path="/voice"
-          fullPath = parsed.host ? `/${parsed.host}${parsed.pathname}` : parsed.pathname;
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          // http(s) link (App Link / Universal Link): host is the domain, not a
+          // path segment — the pathname already IS the route.
+          const p = parsed.pathname + parsed.search;
+          if (p && p !== '/') fullPath = p;
+        } else {
+          // Custom scheme: budget://expense/voice has host="expense", path="/voice"
+          const path = parsed.pathname || parsed.host;
+          if (path && path !== '/') {
+            fullPath = parsed.host ? `/${parsed.host}${parsed.pathname}` : parsed.pathname;
+          }
         }
       } catch {
         // Fallback: strip scheme manually

--- a/apps/mobile/src/db/client.web.ts
+++ b/apps/mobile/src/db/client.web.ts
@@ -46,6 +46,22 @@ export const db = {
   }),
 };
 
+export type QueryResult<T = Record<string, unknown>> = T[];
+
+// Raw-SQL escape hatch used by the repositories. expo-sqlite has no web
+// backend, so this is a no-op that always resolves to an empty result set.
+// IMPORTANT: this MUST be exported here — repositories import `executeSql`
+// from `./client`, which Metro resolves to this file on web. If it is missing,
+// the import is `undefined` and every repository call throws at runtime
+// (e.g. accounts never load after login on https://ai-budget.pl). Stores are
+// expected to fall back to the API response when this returns no rows.
+export function executeSql<T = Record<string, unknown>>(
+  _sql: string,
+  _params?: (string | number | null)[],
+): Promise<QueryResult<T>> {
+  return Promise.resolve([]);
+}
+
 // Database initialization
 export async function initializeDatabase(): Promise<void> {
   // web mock — no-op

--- a/apps/mobile/src/stores/accountStore.ts
+++ b/apps/mobile/src/stores/accountStore.ts
@@ -66,6 +66,24 @@ async function getCurrentUserId(): Promise<string | null> {
   }
 }
 
+// Normalize a server account payload into the in-memory shape the store uses.
+// Used as a fallback when the local SQLite read-back returns no rows — notably
+// on web, where SQLite is a no-op mock, so the round-trip through the local DB
+// would otherwise drop the accounts the API just returned.
+function toAccountWithRole(
+  account: Account & { myRole?: AccountRole },
+  userId: string | null,
+): Account & { myRole: AccountRole } {
+  const myRole: AccountRole =
+    account.myRole ?? (userId && account.ownerId === userId ? 'owner' : 'editor');
+  return {
+    ...account,
+    myRole,
+    createdAt: account.createdAt ? new Date(account.createdAt) : new Date(),
+    updatedAt: account.updatedAt ? new Date(account.updatedAt) : new Date(),
+  };
+}
+
 export const useAccountStore = create<AccountState>()((set, get) => ({
   accounts: [],
   currentAccountId: null,
@@ -84,7 +102,15 @@ export const useAccountStore = create<AccountState>()((set, get) => ({
       await insertAccounts(serverAccounts as (Account & { myRole?: AccountRole })[], userId);
 
       // Load from local DB to get consistent format with myRole (filtered by userId)
-      const localAccounts = await loadAllAccounts(userId);
+      let localAccounts = await loadAllAccounts(userId);
+
+      // Web (no real SQLite) returns nothing from the read-back — fall back to
+      // the server payload so the accounts the API returned are still shown.
+      if (localAccounts.length === 0 && serverAccounts.length > 0) {
+        localAccounts = serverAccounts.map((a) =>
+          toAccountWithRole(a as Account & { myRole?: AccountRole }, userId),
+        );
+      }
 
       const currentId = defaultAccountId || localAccounts[0]?.id || null;
 
@@ -147,7 +173,16 @@ export const useAccountStore = create<AccountState>()((set, get) => ({
         await insertAccounts(serverAccounts, userId);
       }
 
-      const localAccounts = await loadAllAccounts(userId ?? undefined);
+      let localAccounts = await loadAllAccounts(userId ?? undefined);
+
+      // Web (no real SQLite) returns nothing from the read-back — fall back to
+      // the server payload so the accounts the API returned are still shown.
+      if (localAccounts.length === 0 && serverAccounts.length > 0) {
+        localAccounts = serverAccounts.map((a) =>
+          toAccountWithRole(a as Account & { myRole?: AccountRole }, userId),
+        );
+      }
+
       const { currentAccountId } = get();
 
       set({


### PR DESCRIPTION
## Problem

Two bugs in the static web build (https://ai-budget.pl), reported by a user:

1. **Login works but no accounts show.** Nothing else loads because without a selected account the `X-Account-Id` header is empty.
2. After a redirect the URL became malformed: `https://ai-budget.pl/ai-budget.pl/expenses` (domain duplicated in the path), then errored.

## Root causes

**1. Accounts not loading**
- `executeSql` was **missing entirely** from `apps/mobile/src/db/client.web.ts` (the web SQLite mock). Repositories import `executeSql` from `./client`, which Metro resolves to `client.web.ts` on web → the import was `undefined` and every repository call threw at runtime.
- `accountStore` inserts server accounts into SQLite then **reads them back** to build state. On web that read-back is a no-op mock, so the accounts the API returned were dropped.

**2. Doubled-domain deep-link path**
- The deep-link handler in `app/_layout.tsx` was written for the native custom scheme `budget://expense/voice`, where the first path segment lands in `URL.host`, so it builds `fullPath = /${host}${pathname}`.
- On web, `Linking.getInitialURL()` returns the full browser URL `https://ai-budget.pl/expenses`, whose `host` is the **domain** → it built `/ai-budget.pl/expenses` and `router.push`ed it → `https://ai-budget.pl/ai-budget.pl/expenses`.

## Changes

- **`client.web.ts`**: add the missing `executeSql` (+ `QueryResult` type) export as a no-op resolving to `[]`, so web repository calls stop throwing.
- **`accountStore.ts`**: in `initialize` and `loadAccountsFromServer`, fall back to the server account payload when the local SQLite read-back is empty (via a new `toAccountWithRole` normalizer). Native is unchanged — the fallback only triggers when the local read returns nothing.
- **`_layout.tsx`**: skip the deep-link effect on web (Expo Router already routes browser URLs natively), and distinguish `http(s)` URLs from custom-scheme URLs in the parser so native App Links / Universal Links can't hit the same host-as-segment corruption.

## Native (iOS/Android) impact

None.
- `client.web.ts` is web-only (`.web.ts`); native uses `client.native.ts`.
- `accountStore` fallback is skipped whenever the local DB returns rows (normal native path) — behavior is byte-for-byte identical.
- The deep-link parser's `else` branch reproduces the original logic exactly. Verified against the actual widget URIs (`budget://expense/voice`, `/receipt`, `/new`) → identical output. The new `http(s)` branch is unreachable on native today (no App Links registered for `ai-budget.pl`).

## Notes

- Deps aren't installed in the dev environment, so a full `typecheck` couldn't run here; changes are small and type-safe. Please confirm in CI.
- These fixes take effect on web only after a rebuild — the `web-deploy.yml` workflow runs on push to `development`.

https://claude.ai/code/session_01YbXanDG36iK3uw4eRnuLTU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbXanDG36iK3uw4eRnuLTU)_