### PR TITLE
fix(mobile/web): make Alert-based dialogs work on web (Save expense and 213 other call sites)

### DIFF
--- a/apps/mobile/app/(auth)/reset-password.tsx
+++ b/apps/mobile/app/(auth)/reset-password.tsx
@@ -6,8 +6,8 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   ScrollView,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { router, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -71,7 +71,7 @@ export default function ResetPasswordScreen() {
 
     try {
       await resetPassword(email!, code, newPassword);
-      Alert.alert('', t('auth.passwordResetSuccess'));
+      showAlert('', t('auth.passwordResetSuccess'));
       router.replace('/(auth)/login');
     } catch (e) {
       const msg = e instanceof Error ? e.message : '';

--- a/apps/mobile/app/(tabs)/chat.tsx
+++ b/apps/mobile/app/(tabs)/chat.tsx
@@ -6,10 +6,10 @@ import {
   TextInput,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   StyleSheet,
   Platform,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -85,7 +85,7 @@ export default function ChatScreen() {
   }, [messages]);
 
   useEffect(() => {
-    if (voiceError) Alert.alert(t('common.error'), voiceError);
+    if (voiceError) showAlert(t('common.error'), voiceError);
   }, [voiceError, t]);
 
   useEffect(() => {

--- a/apps/mobile/app/(tabs)/expenses.tsx
+++ b/apps/mobile/app/(tabs)/expenses.tsx
@@ -6,11 +6,11 @@ import {
   RefreshControl,
   Animated,
   ScrollView,
-  Alert,
   ActivityIndicator,
   TextInput,
   Modal,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -215,7 +215,7 @@ export default function ExpensesScreen() {
 
   const handleDeleteFromList = () => {
     if (!selectedTransaction) return;
-    Alert.alert(t('common.deleteConfirmTitle'), t('common.deleteConfirmMessage'), [
+    showAlert(t('common.deleteConfirmTitle'), t('common.deleteConfirmMessage'), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/account/[id].tsx
+++ b/apps/mobile/app/account/[id].tsx
@@ -4,9 +4,9 @@ import {
   Text,
   TouchableOpacity,
   TextInput,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router, useLocalSearchParams, useFocusEffect } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -88,12 +88,12 @@ export default function AccountDetailScreen() {
       await updateAccount(id, { name: name.trim() });
       setEditMode(false);
     } catch (e) {
-      Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
   const handleDelete = () => {
-    Alert.alert(
+    showAlert(
       t('accounts.deleteConfirm'),
       t('accounts.deleteConfirmMessage', { name: account.name }),
       [
@@ -106,7 +106,7 @@ export default function AccountDetailScreen() {
               await deleteAccount(id!);
               router.back();
             } catch (e) {
-              Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },
@@ -115,7 +115,7 @@ export default function AccountDetailScreen() {
   };
 
   const handleLeave = () => {
-    Alert.alert(
+    showAlert(
       t('accounts.leaveConfirm'),
       t('accounts.leaveConfirmMessage', { name: account.name }),
       [
@@ -128,7 +128,7 @@ export default function AccountDetailScreen() {
               await leaveAccount(id!);
               router.back();
             } catch (e) {
-              Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },
@@ -137,7 +137,7 @@ export default function AccountDetailScreen() {
   };
 
   const handleRemoveMember = (member: AccountMember) => {
-    Alert.alert(
+    showAlert(
       t('accounts.removeMemberConfirm'),
       t('accounts.removeMemberMessage', { name: member.user?.name || member.user?.email }),
       [
@@ -149,7 +149,7 @@ export default function AccountDetailScreen() {
             try {
               await removeMember(id!, member.id);
             } catch (e) {
-              Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },
@@ -158,7 +158,7 @@ export default function AccountDetailScreen() {
   };
 
   const handleCancelInvitation = (invitation: AccountInvitation) => {
-    Alert.alert(
+    showAlert(
       t('accounts.cancelInvitation'),
       t('accounts.cancelInvitationMessage'),
       [
@@ -171,7 +171,7 @@ export default function AccountDetailScreen() {
               await api.cancelInvitation(id!, invitation.id);
               setInvitations((prev) => prev.filter((inv) => inv.id !== invitation.id));
             } catch (e) {
-              Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },
@@ -187,12 +187,12 @@ export default function AccountDetailScreen() {
         try {
           await updateMemberRole(id!, member.id, role);
         } catch (e) {
-          Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+          showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
         }
       },
     }));
     buttons.push({ text: t('common.cancel'), onPress: async () => {} });
-    Alert.alert(t('accounts.changeRole'), t('accounts.selectRole'), buttons as any);
+    showAlert(t('accounts.changeRole'), t('accounts.selectRole'), buttons as any);
   };
 
   return (

--- a/apps/mobile/app/account/create.tsx
+++ b/apps/mobile/app/account/create.tsx
@@ -4,9 +4,9 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -39,7 +39,7 @@ export default function CreateAccountScreen() {
 
   const handleCreate = async () => {
     if (!name.trim()) {
-      Alert.alert(t('errors.error'), t('accounts.nameRequired'));
+      showAlert(t('errors.error'), t('accounts.nameRequired'));
       return;
     }
 
@@ -47,7 +47,7 @@ export default function CreateAccountScreen() {
       await createAccount({ name: name.trim(), type, currencyCode });
       router.back();
     } catch (e) {
-      Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 

--- a/apps/mobile/app/account/invite.tsx
+++ b/apps/mobile/app/account/invite.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
   Share,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -40,7 +40,7 @@ export default function InviteScreen() {
     if (!accountId) return;
 
     if (mode === 'email' && !email.trim()) {
-      Alert.alert(t('errors.error'), t('accounts.emailRequired'));
+      showAlert(t('errors.error'), t('accounts.emailRequired'));
       return;
     }
 
@@ -52,7 +52,7 @@ export default function InviteScreen() {
       });
       setInviteCode(invitation.inviteCode);
     } catch (e) {
-      Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setIsLoading(false);
     }
@@ -61,7 +61,7 @@ export default function InviteScreen() {
   const handleCopyCode = async () => {
     if (inviteCode) {
       await Clipboard.setStringAsync(inviteCode);
-      Alert.alert(t('common.success'), t('accounts.codeCopied'));
+      showAlert(t('common.success'), t('accounts.codeCopied'));
     }
   };
 

--- a/apps/mobile/app/account/join.tsx
+++ b/apps/mobile/app/account/join.tsx
@@ -4,9 +4,9 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -26,18 +26,18 @@ export default function JoinAccountScreen() {
 
   const handleJoin = async () => {
     if (!inviteCode.trim()) {
-      Alert.alert(t('errors.error'), t('accounts.codeRequired'));
+      showAlert(t('errors.error'), t('accounts.codeRequired'));
       return;
     }
 
     setIsLoading(true);
     try {
       await acceptInvitation(inviteCode.trim());
-      Alert.alert(t('common.success'), t('accounts.joinedSuccess'), [
+      showAlert(t('common.success'), t('accounts.joinedSuccess'), [
         { text: t('common.ok'), onPress: () => router.back() },
       ]);
     } catch (e) {
-      Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setIsLoading(false);
     }

--- a/apps/mobile/app/account/list.tsx
+++ b/apps/mobile/app/account/list.tsx
@@ -4,8 +4,8 @@ import {
   Text,
   FlatList,
   TouchableOpacity,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -36,7 +36,7 @@ export default function AccountListScreen() {
   };
 
   const handleDelete = (id: string, name: string) => {
-    Alert.alert(
+    showAlert(
       t('accounts.deleteConfirm'),
       t('accounts.deleteConfirmMessage', { name }),
       [
@@ -48,7 +48,7 @@ export default function AccountListScreen() {
             try {
               await deleteAccount(id);
             } catch (e) {
-              Alert.alert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('errors.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },

--- a/apps/mobile/app/budget/[id].tsx
+++ b/apps/mobile/app/budget/[id].tsx
@@ -4,8 +4,8 @@ import {
   Text,
   TouchableOpacity,
   ScrollView,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -144,7 +144,7 @@ export default function BudgetDetailScreen() {
   };
 
   const handleDelete = () => {
-    Alert.alert(t('budgetDetail.deleteTitle'), t('budgetDetail.deleteConfirm'), [
+    showAlert(t('budgetDetail.deleteTitle'), t('budgetDetail.deleteConfirm'), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/budget/new.tsx
+++ b/apps/mobile/app/budget/new.tsx
@@ -5,8 +5,8 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -56,7 +56,7 @@ export default function NewBudgetScreen() {
 
   const handleSubmit = async () => {
     if (!name.trim()) {
-      Alert.alert(t('common.error'), t('budgetNew.errorName'));
+      showAlert(t('common.error'), t('budgetNew.errorName'));
       return;
     }
 
@@ -65,12 +65,12 @@ export default function NewBudgetScreen() {
       : parseFloat(amount);
 
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(t('common.error'), t('budgetNew.errorAmount'));
+      showAlert(t('common.error'), t('budgetNew.errorAmount'));
       return;
     }
 
     if (budgetMode === 'byCategory' && categoryAllocations.length === 0) {
-      Alert.alert(t('common.error'), t('budgetNew.errorNoCategories'));
+      showAlert(t('common.error'), t('budgetNew.errorNoCategories'));
       return;
     }
 
@@ -112,7 +112,7 @@ export default function NewBudgetScreen() {
 
       router.back();
     } catch {
-      Alert.alert(t('common.error'), t('budgetNew.errorFailed'));
+      showAlert(t('common.error'), t('budgetNew.errorFailed'));
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/mobile/app/expense/[id].tsx
+++ b/apps/mobile/app/expense/[id].tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { View, Text, TouchableOpacity, Alert } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -57,7 +58,7 @@ export default function ExpenseDetailScreen() {
   }
 
   const handleStopRecurring = () => {
-    Alert.alert(
+    showAlert(
       t('recurring.stopRecurring'),
       t('recurring.stopRecurringConfirm'),
       [
@@ -68,9 +69,9 @@ export default function ExpenseDetailScreen() {
           onPress: async () => {
             try {
               await stopRecurringExpense(expense.id);
-              Alert.alert('', t('recurring.stopped'));
+              showAlert('', t('recurring.stopped'));
             } catch {
-              Alert.alert(t('common.error'), t('errors.saveFailed'));
+              showAlert(t('common.error'), t('errors.saveFailed'));
             }
           },
         },
@@ -92,7 +93,7 @@ export default function ExpenseDetailScreen() {
   };
 
   const handleDelete = () => {
-    Alert.alert(t('expenseDetail.deleteTitle'), t('expenseDetail.deleteConfirm'), [
+    showAlert(t('expenseDetail.deleteTitle'), t('expenseDetail.deleteConfirm'), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/expense/components/ExpenseDetailsCard.tsx
+++ b/apps/mobile/app/expense/components/ExpenseDetailsCard.tsx
@@ -3,10 +3,10 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   TextInput,
   Platform,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
@@ -113,7 +113,7 @@ export const ExpenseDetailsCard = forwardRef<ExpenseDetailsCardHandle, ExpenseDe
       triggerSave: async () => {
         const numericAmount = parseFloat(editAmount);
         if (!numericAmount || numericAmount <= 0) {
-          Alert.alert(t('common.error'), t('validation.invalidAmount'));
+          showAlert(t('common.error'), t('validation.invalidAmount'));
           return;
         }
 
@@ -179,7 +179,7 @@ export const ExpenseDetailsCard = forwardRef<ExpenseDetailsCardHandle, ExpenseDe
     };
 
     const handleRemoveSplits = async () => {
-      Alert.alert(t('splits.removeSplit'), '', [
+      showAlert(t('splits.removeSplit'), '', [
         { text: t('common.cancel'), style: 'cancel' },
         {
           text: t('common.delete'),

--- a/apps/mobile/app/expense/components/ExpenseItemsSection.tsx
+++ b/apps/mobile/app/expense/components/ExpenseItemsSection.tsx
@@ -3,10 +3,10 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   TextInput,
   Modal,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { formatCurrency } from '@budget/shared-utils';
@@ -60,7 +60,7 @@ export function ExpenseItemsSection({ expenseId, currencyCode }: ExpenseItemsSec
   const handleSaveItem = () => {
     const total = parseFloat(itemTotalPrice);
     if (!itemDescription.trim() || isNaN(total) || total <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
@@ -84,7 +84,7 @@ export function ExpenseItemsSection({ expenseId, currencyCode }: ExpenseItemsSec
   };
 
   const handleDeleteItem = (item: ExpenseItem) => {
-    Alert.alert(t('expenseDetail.confirmDeleteItem'), '', [
+    showAlert(t('expenseDetail.confirmDeleteItem'), '', [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/expense/components/ReceiptSection.tsx
+++ b/apps/mobile/app/expense/components/ReceiptSection.tsx
@@ -3,12 +3,12 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   Image,
   Modal,
   ActivityIndicator,
   InteractionManager,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import * as ImagePicker from 'expo-image-picker';
@@ -69,13 +69,13 @@ export function ReceiptSection({ expenseId }: ReceiptSectionProps) {
     if (isPdf) return handleShareImage();
     const { status } = await MediaLibrary.requestPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert(t('common.error'), t('expenseDetail.galleryPermissionDenied'));
+      showAlert(t('common.error'), t('expenseDetail.galleryPermissionDenied'));
       return;
     }
     const file = new File(Paths.cache, `receipt-${expenseId}.jpg`);
     file.write(receiptImageBase64, { encoding: 'base64' });
     await MediaLibrary.saveToLibraryAsync(file.uri);
-    Alert.alert('', t('expenseDetail.imageSaved'));
+    showAlert('', t('expenseDetail.imageSaved'));
   };
 
   const compressImageToBase64 = async (uri: string): Promise<string> => {
@@ -91,7 +91,7 @@ export function ReceiptSection({ expenseId }: ReceiptSectionProps) {
   const handleAttachFromCamera = async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert(t('common.error'), t('expenseDetail.cameraPermissionDenied'));
+      showAlert(t('common.error'), t('expenseDetail.cameraPermissionDenied'));
       return;
     }
     const result = await ImagePicker.launchCameraAsync({ mediaTypes: ['images'], quality: 0.8 });
@@ -126,7 +126,7 @@ export function ReceiptSection({ expenseId }: ReceiptSectionProps) {
   };
 
   const handleShowAttachOptions = () => {
-    Alert.alert(
+    showAlert(
       t('expenseDetail.attachReceipt'),
       undefined,
       [
@@ -140,7 +140,7 @@ export function ReceiptSection({ expenseId }: ReceiptSectionProps) {
   };
 
   const handleDeleteImage = () => {
-    Alert.alert(t('expenseDetail.confirmDeleteImage'), '', [
+    showAlert(t('expenseDetail.confirmDeleteImage'), '', [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/expense/new.tsx
+++ b/apps/mobile/app/expense/new.tsx
@@ -5,10 +5,10 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
   Platform,
   Switch,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -100,12 +100,12 @@ export default function NewExpenseScreen() {
   const handleSubmit = async () => {
     const numericAmount = parseFloat(amount);
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
     if (!description.trim()) {
-      Alert.alert(t('common.error'), t('validation.noDescription'));
+      showAlert(t('common.error'), t('validation.noDescription'));
       return;
     }
 
@@ -164,7 +164,7 @@ export default function NewExpenseScreen() {
 
       router.back();
     } catch {
-      Alert.alert(t('common.error'), t('errors.saveFailed'));
+      showAlert(t('common.error'), t('errors.saveFailed'));
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/mobile/app/expense/receipt.tsx
+++ b/apps/mobile/app/expense/receipt.tsx
@@ -5,9 +5,9 @@ import {
   TextInput,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   Image,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -64,7 +64,7 @@ export default function ReceiptExpenseScreen() {
 
   useEffect(() => {
     if (error) {
-      Alert.alert(t('common.error'), error, [{ text: 'OK', onPress: reset }]);
+      showAlert(t('common.error'), error, [{ text: 'OK', onPress: reset }]);
     }
   }, [error, reset, t]);
 
@@ -146,12 +146,12 @@ export default function ReceiptExpenseScreen() {
         receiptImageBase64,
       });
 
-      Alert.alert(t('common.success'), t('receipt.success'), [
+      showAlert(t('common.success'), t('receipt.success'), [
         { text: t('receipt.scanAnother'), onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {
-      Alert.alert(t('common.error'), t('receipt.saveFailed'));
+      showAlert(t('common.error'), t('receipt.saveFailed'));
     }
   };
 

--- a/apps/mobile/app/expense/voice.tsx
+++ b/apps/mobile/app/expense/voice.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   TextInput,
   ScrollView,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -64,7 +64,7 @@ export default function VoiceExpenseScreen() {
 
   useEffect(() => {
     if (error) {
-      Alert.alert(t('common.error'), error, [{ text: 'OK', onPress: resetVoice }]);
+      showAlert(t('common.error'), error, [{ text: 'OK', onPress: resetVoice }]);
     }
   }, [error, resetVoice, t]);
 
@@ -105,12 +105,12 @@ export default function VoiceExpenseScreen() {
   const handleConfirmExpense = async () => {
     const numericAmount = parseFloat(editAmount);
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
     if (!editDescription.trim()) {
-      Alert.alert(t('common.error'), t('validation.noDescription'));
+      showAlert(t('common.error'), t('validation.noDescription'));
       return;
     }
 
@@ -129,12 +129,12 @@ export default function VoiceExpenseScreen() {
         isDebtRepayment: false,
       });
 
-      Alert.alert(t('common.success'), t('voice.success'), [
+      showAlert(t('common.success'), t('voice.success'), [
         { text: t('voice.addAnother'), onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {
-      Alert.alert(t('common.error'), t('voice.saveFailed'));
+      showAlert(t('common.error'), t('voice.saveFailed'));
     }
   };
 

--- a/apps/mobile/app/goals/[id].tsx
+++ b/apps/mobile/app/goals/[id].tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, Alert, RefreshControl } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, RefreshControl } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Stack, useLocalSearchParams, router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -57,7 +58,7 @@ export default function GoalDetailScreen() {
   }, [loadProgressData]);
 
   const handleDelete = () => {
-    Alert.alert(
+    showAlert(
       t('goals.deleteTitle') || 'Delete Goal',
       t('goals.deleteConfirm') || `Are you sure you want to delete "${goal?.name}"?`,
       [
@@ -70,7 +71,7 @@ export default function GoalDetailScreen() {
               await deleteGoal(id!);
               setTimeout(() => router.back(), 0);
             } catch {
-              Alert.alert(t('common.error'), t('goals.errorDelete') || 'Failed to delete goal');
+              showAlert(t('common.error'), t('goals.errorDelete') || 'Failed to delete goal');
             }
           },
         },
@@ -85,7 +86,7 @@ export default function GoalDetailScreen() {
       await regeneratePlan(id);
       await loadProgressData();
     } catch {
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('goals.errorRegenerate') || 'Failed to regenerate plan',
       );
@@ -102,7 +103,7 @@ export default function GoalDetailScreen() {
       await loadProgressData();
       setShowAddFunds(false);
     } catch {
-      Alert.alert(t('common.error'), t('goals.errorAddFunds') || 'Failed to add funds');
+      showAlert(t('common.error'), t('goals.errorAddFunds') || 'Failed to add funds');
     }
   };
 

--- a/apps/mobile/app/goals/new.tsx
+++ b/apps/mobile/app/goals/new.tsx
@@ -5,9 +5,9 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
   Platform,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -58,7 +58,7 @@ export default function NewGoalScreen() {
 
   const handleCreate = async () => {
     if (!name.trim()) {
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('goals.errorName') || 'Please enter a goal name',
       );
@@ -67,7 +67,7 @@ export default function NewGoalScreen() {
 
     const numericAmount = parseFloat(targetAmount);
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('goals.errorAmount') || 'Please enter a valid target amount',
       );
@@ -75,7 +75,7 @@ export default function NewGoalScreen() {
     }
 
     if (!deadlineDate) {
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('goals.errorDeadline') || 'Please set a deadline',
       );
@@ -83,7 +83,7 @@ export default function NewGoalScreen() {
     }
 
     if (deadlineDate <= new Date()) {
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('goals.errorPastDate') || 'Deadline must be in the future',
       );
@@ -100,7 +100,7 @@ export default function NewGoalScreen() {
       });
       router.back();
     } catch {
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('goals.errorCreate') || 'Failed to create goal. Please try again.',
       );

--- a/apps/mobile/app/income/[id].tsx
+++ b/apps/mobile/app/income/[id].tsx
@@ -3,10 +3,10 @@ import {
   View,
   Text,
   TouchableOpacity,
-  Alert,
   TextInput,
   Platform,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -79,7 +79,7 @@ export default function IncomeDetailScreen() {
   };
 
   const handleDelete = () => {
-    Alert.alert(
+    showAlert(
       t('incomeDetail.deleteTitle'),
       t('incomeDetail.deleteConfirm'),
       [

--- a/apps/mobile/app/income/new.tsx
+++ b/apps/mobile/app/income/new.tsx
@@ -5,10 +5,10 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
   Platform,
   Switch,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -74,12 +74,12 @@ export default function NewIncomeScreen() {
   const handleSubmit = async () => {
     const numericAmount = parseFloat(amount);
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
     if (!description.trim()) {
-      Alert.alert(t('common.error'), t('validation.noDescription'));
+      showAlert(t('common.error'), t('validation.noDescription'));
       return;
     }
 
@@ -103,7 +103,7 @@ export default function NewIncomeScreen() {
 
       router.back();
     } catch {
-      Alert.alert(t('common.error'), t('errors.saveFailed'));
+      showAlert(t('common.error'), t('errors.saveFailed'));
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/mobile/app/income/receipt.tsx
+++ b/apps/mobile/app/income/receipt.tsx
@@ -5,9 +5,9 @@ import {
   TextInput,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   Image,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -47,7 +47,7 @@ export default function ReceiptIncomeScreen() {
 
   useEffect(() => {
     if (error) {
-      Alert.alert(t('common.error'), error, [{ text: 'OK', onPress: reset }]);
+      showAlert(t('common.error'), error, [{ text: 'OK', onPress: reset }]);
     }
   }, [error, reset, t]);
 
@@ -86,12 +86,12 @@ export default function ReceiptIncomeScreen() {
         isDebtRepayment: false,
       });
 
-      Alert.alert(t('common.success'), t('incomeReceipt.success'), [
+      showAlert(t('common.success'), t('incomeReceipt.success'), [
         { text: t('incomeReceipt.scanAnother'), onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {
-      Alert.alert(t('common.error'), t('incomeReceipt.saveFailed'));
+      showAlert(t('common.error'), t('incomeReceipt.saveFailed'));
     }
   };
 

--- a/apps/mobile/app/income/voice.tsx
+++ b/apps/mobile/app/income/voice.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   TextInput,
   ScrollView,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -66,7 +66,7 @@ export default function VoiceIncomeScreen() {
 
   useEffect(() => {
     if (error) {
-      Alert.alert(t('common.error'), error, [{ text: 'OK', onPress: handleReset }]);
+      showAlert(t('common.error'), error, [{ text: 'OK', onPress: handleReset }]);
     }
   }, [error, t]);
 
@@ -148,11 +148,11 @@ export default function VoiceIncomeScreen() {
   const handleConfirmIncome = async () => {
     const numericAmount = parseFloat(editAmount);
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
     if (!editDescription.trim()) {
-      Alert.alert(t('common.error'), t('validation.noDescription'));
+      showAlert(t('common.error'), t('validation.noDescription'));
       return;
     }
     try {
@@ -167,12 +167,12 @@ export default function VoiceIncomeScreen() {
         isDebt: false,
         isDebtRepayment: false,
       });
-      Alert.alert(t('common.success'), t('incomeVoice.success'), [
+      showAlert(t('common.success'), t('incomeVoice.success'), [
         { text: t('incomeVoice.addAnother'), onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {
-      Alert.alert(t('common.error'), t('incomeVoice.saveFailed'));
+      showAlert(t('common.error'), t('incomeVoice.saveFailed'));
     }
   };
 

--- a/apps/mobile/app/investment/[holdingId].tsx
+++ b/apps/mobile/app/investment/[holdingId].tsx
@@ -1,4 +1,5 @@
-import { View, Text, FlatList, TouchableOpacity, Alert, Image, ActivityIndicator } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { useState, useEffect, useMemo } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -63,7 +64,7 @@ export default function AssetDetailScreen() {
   }, [priceHistory]);
 
   const handleDeleteTransaction = (transactionId: string) => {
-    Alert.alert(
+    showAlert(
       t('investments.deleteTransaction'),
       t('investments.deleteTransactionConfirm'),
       [
@@ -80,7 +81,7 @@ export default function AssetDetailScreen() {
   };
 
   const handleDeleteHolding = () => {
-    Alert.alert(
+    showAlert(
       t('investments.deleteHolding'),
       t('investments.deleteHoldingConfirm'),
       [

--- a/apps/mobile/app/investment/transaction.tsx
+++ b/apps/mobile/app/investment/transaction.tsx
@@ -1,4 +1,5 @@
-import { View, Text, ScrollView, TouchableOpacity, TextInput, Alert } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { useState } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -41,17 +42,17 @@ export default function AddTransactionScreen() {
 
   const handleSave = () => {
     if (!quantity || quantityNum <= 0) {
-      Alert.alert(t('common.error'), t('investments.invalidQuantity'));
+      showAlert(t('common.error'), t('investments.invalidQuantity'));
       return;
     }
 
     if (!pricePerUnit || priceNum <= 0) {
-      Alert.alert(t('common.error'), t('investments.invalidPrice'));
+      showAlert(t('common.error'), t('investments.invalidPrice'));
       return;
     }
 
     if (!holdingId) {
-      Alert.alert(t('common.error'), t('investments.holdingNotFound'));
+      showAlert(t('common.error'), t('investments.holdingNotFound'));
       return;
     }
 

--- a/apps/mobile/app/projects/[id].tsx
+++ b/apps/mobile/app/projects/[id].tsx
@@ -1,7 +1,13 @@
 import React, { useMemo, useState } from 'react';
 import {
-  View, Text, ScrollView, TouchableOpacity, Alert, Modal, TextInput,
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Modal,
+  TextInput,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { Stack, useLocalSearchParams, router } from 'expo-router';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -64,7 +70,7 @@ export default function ProjectDetailScreen() {
       });
       closeEdit();
     } catch {
-      Alert.alert(t('common.error'), t('common.retry'));
+      showAlert(t('common.error'), t('common.retry'));
     } finally {
       setIsSaving(false);
     }
@@ -72,7 +78,7 @@ export default function ProjectDetailScreen() {
 
   const handleDelete = () => {
     if (!project) return;
-    Alert.alert(t('projects.deleteProject'), t('projects.confirmDelete'), [
+    showAlert(t('projects.deleteProject'), t('projects.confirmDelete'), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'), style: 'destructive',

--- a/apps/mobile/app/projects/index.tsx
+++ b/apps/mobile/app/projects/index.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import {
-  View, Text, ScrollView, TouchableOpacity, Alert, Modal, TextInput,
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Modal,
+  TextInput,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { Stack, router } from 'expo-router';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -57,7 +63,7 @@ export default function ProjectsScreen() {
 
   const handleCreate = async () => {
     const trimmed = name.trim();
-    if (!trimmed) { Alert.alert(t('common.error'), t('projects.projectName')); return; }
+    if (!trimmed) { showAlert(t('common.error'), t('projects.projectName')); return; }
     setIsSaving(true);
     try {
       await createProject({
@@ -68,14 +74,14 @@ export default function ProjectsScreen() {
       });
       closeModal();
     } catch {
-      Alert.alert(t('common.error'), t('common.retry'));
+      showAlert(t('common.error'), t('common.retry'));
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleDelete = (project: Project) => {
-    Alert.alert(t('projects.deleteProject'), t('projects.confirmDelete'), [
+    showAlert(t('projects.deleteProject'), t('projects.confirmDelete'), [
       { text: t('common.cancel'), style: 'cancel' },
       { text: t('common.delete'), style: 'destructive', onPress: () => deleteProject(project.id) },
     ]);

--- a/apps/mobile/app/projects/new.tsx
+++ b/apps/mobile/app/projects/new.tsx
@@ -5,8 +5,8 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
@@ -34,7 +34,7 @@ export default function NewProjectScreen() {
 
   const handleCreate = async () => {
     if (!name.trim()) {
-      Alert.alert(t('common.error'), t('projects.projectName'));
+      showAlert(t('common.error'), t('projects.projectName'));
       return;
     }
 
@@ -48,7 +48,7 @@ export default function NewProjectScreen() {
       });
       router.back();
     } catch {
-      Alert.alert(t('common.error'), t('common.retry'));
+      showAlert(t('common.error'), t('common.retry'));
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/mobile/app/reports.tsx
+++ b/apps/mobile/app/reports.tsx
@@ -4,9 +4,9 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
@@ -106,7 +106,7 @@ export default function ReportsScreen() {
   };
 
   const handleDelete = (report: ReportListItem) => {
-    Alert.alert(
+    showAlert(
       t('reports.deleteTitle'),
       t('reports.deleteConfirm'),
       [

--- a/apps/mobile/app/scenario-simulator.tsx
+++ b/apps/mobile/app/scenario-simulator.tsx
@@ -6,10 +6,10 @@ import {
   TouchableOpacity,
   TextInput,
   Modal,
-  Alert,
   FlatList,
   Share,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -97,7 +97,7 @@ export default function ScenarioSimulatorScreen() {
   // --- Save ---
   const handleSavePress = useCallback(() => {
     if (!canSave(isPro)) {
-      Alert.alert(
+      showAlert(
         t('scenarioSimulator.savedScenarios'),
         t('scenarioSimulator.scenarioLimitFree'),
       );
@@ -111,9 +111,9 @@ export default function ScenarioSimulatorScreen() {
     const result = saveScenario(scenarioName, { expenseAdj, incomeAdj, extraIncomes, horizon }, isPro);
     setSaveModalVisible(false);
     if (result === 'ok') {
-      Alert.alert('', t('scenarioSimulator.scenarioSaved'));
+      showAlert('', t('scenarioSimulator.scenarioSaved'));
     } else {
-      Alert.alert(
+      showAlert(
         t('scenarioSimulator.savedScenarios'),
         t('scenarioSimulator.scenarioLimitFree'),
       );
@@ -130,7 +130,7 @@ export default function ScenarioSimulatorScreen() {
   }, []);
 
   const handleDeleteScenario = useCallback((id: string) => {
-    Alert.alert(
+    showAlert(
       t('scenarioSimulator.deleteScenario'),
       t('common.deleteConfirmMessage'),
       [

--- a/apps/mobile/app/settings/bots.tsx
+++ b/apps/mobile/app/settings/bots.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  Alert,
   ActivityIndicator,
   Linking,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 
 const API_ORIGIN = (process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000/api/v1').replace(
   /\/api(\/v1)?\/?$/,
@@ -84,7 +84,7 @@ export default function BotsSettingsScreen() {
       setTelegramLinkCode(result.code);
       setTelegramBotUsername(result.botUsername);
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setTelegramLoading(false);
     }
@@ -93,12 +93,12 @@ export default function BotsSettingsScreen() {
   const handleCopyTelegramCode = async () => {
     if (telegramLinkCode) {
       await Clipboard.setStringAsync(telegramLinkCode);
-      Alert.alert(t('settings.telegram.codeCopied'));
+      showAlert(t('settings.telegram.codeCopied'));
     }
   };
 
   const handleUnlinkTelegram = async () => {
-    Alert.alert(
+    showAlert(
       t('settings.telegram.disconnect'),
       t('settings.telegram.disconnectConfirm'),
       [
@@ -113,7 +113,7 @@ export default function BotsSettingsScreen() {
               setTelegramUsername(null);
               setTelegramLinkCode(null);
             } catch (e) {
-              Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },
@@ -159,7 +159,7 @@ export default function BotsSettingsScreen() {
       const result = await api.generateSlackLinkCode();
       setSlackLinkCode(result);
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setSlackCodeLoading(false);
     }
@@ -168,7 +168,7 @@ export default function BotsSettingsScreen() {
   const handleCopySlackCode = async () => {
     if (!slackLinkCode) return;
     await Clipboard.setStringAsync(slackLinkCode.code);
-    Alert.alert('', t('slackBot.copyCode'));
+    showAlert('', t('slackBot.copyCode'));
   };
 
   const handleSlackRefresh = async () => {
@@ -180,7 +180,7 @@ export default function BotsSettingsScreen() {
     Linking.canOpenURL('slack://open').then((supported) => {
       if (supported) {
         Linking.openURL('slack://open').catch(() => {
-          Alert.alert(t('common.error'), t('errors.unknown'));
+          showAlert(t('common.error'), t('errors.unknown'));
         });
       }
     });
@@ -188,12 +188,12 @@ export default function BotsSettingsScreen() {
 
   const handleAddToSlack = () => {
     Linking.openURL(`${API_ORIGIN}/slack/install`).catch(() => {
-      Alert.alert(t('common.error'), t('errors.unknown'));
+      showAlert(t('common.error'), t('errors.unknown'));
     });
   };
 
   const handleUnlinkSlack = () => {
-    Alert.alert(
+    showAlert(
       t('slackBot.confirmDisconnect'),
       '',
       [
@@ -208,7 +208,7 @@ export default function BotsSettingsScreen() {
               setSlackStatus({ linked: false });
               setSlackLinkCode(null);
             } catch (e) {
-              Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
             } finally {
               setSlackUnlinkLoading(false);
             }
@@ -256,7 +256,7 @@ export default function BotsSettingsScreen() {
       const result = await api.generateWhatsAppLinkCode();
       setLinkCode(result);
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setWaCodeLoading(false);
     }
@@ -271,14 +271,14 @@ export default function BotsSettingsScreen() {
     if (!linkCode) return;
     const url = buildWaMeUrl(linkCode.waPhoneNumber, linkCode.code);
     Linking.openURL(url).catch(() => {
-      Alert.alert(t('common.error'), t('errors.unknown'));
+      showAlert(t('common.error'), t('errors.unknown'));
     });
   };
 
   const handleCopyWaCode = async () => {
     if (!linkCode) return;
     await Clipboard.setStringAsync(linkCode.code);
-    Alert.alert('', t('whatsappBot.copyCode'));
+    showAlert('', t('whatsappBot.copyCode'));
   };
 
   const handleWaRefresh = async () => {
@@ -287,7 +287,7 @@ export default function BotsSettingsScreen() {
   };
 
   const handleUnlinkWa = () => {
-    Alert.alert(
+    showAlert(
       t('whatsappBot.confirmDisconnect'),
       '',
       [
@@ -302,7 +302,7 @@ export default function BotsSettingsScreen() {
               setWaStatus({ linked: false });
               setLinkCode(null);
             } catch (e) {
-              Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
             } finally {
               setWaUnlinkLoading(false);
             }

--- a/apps/mobile/app/settings/categories.tsx
+++ b/apps/mobile/app/settings/categories.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  Alert,
   Modal,
   TextInput,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -76,7 +76,7 @@ export default function CategoriesSettingsScreen() {
   const handleSave = async () => {
     const trimmed = name.trim();
     if (!trimmed) {
-      Alert.alert(t('common.error'), t('categoryCreate.nameRequired'));
+      showAlert(t('common.error'), t('categoryCreate.nameRequired'));
       return;
     }
 
@@ -89,14 +89,14 @@ export default function CategoriesSettingsScreen() {
       }
       closeModal();
     } catch {
-      Alert.alert(t('common.error'), t('errors.saveFailed'));
+      showAlert(t('common.error'), t('errors.saveFailed'));
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleDelete = (category: Category) => {
-    Alert.alert(
+    showAlert(
       t('categories.deleteConfirmTitle'),
       t('categories.deleteConfirmMessage', { name: category.name }),
       [
@@ -107,11 +107,11 @@ export default function CategoriesSettingsScreen() {
           onPress: async () => {
             try {
               await deleteCategory(category.id);
-              Alert.alert(t('categories.deleteSuccess'));
+              showAlert(t('categories.deleteSuccess'));
             } catch (error: any) {
               if (error?.status === 409) {
                 const d = error.details || {};
-                Alert.alert(
+                showAlert(
                   t('common.error'),
                   t('categories.deleteErrorHasRecords', {
                     expenses: d.expenses || 0,
@@ -121,7 +121,7 @@ export default function CategoriesSettingsScreen() {
                   }),
                 );
               } else {
-                Alert.alert(t('common.error'), error?.message || t('common.error'));
+                showAlert(t('common.error'), error?.message || t('common.error'));
               }
             }
           },

--- a/apps/mobile/app/settings/change-email.tsx
+++ b/apps/mobile/app/settings/change-email.tsx
@@ -4,9 +4,9 @@ import {
   Text,
   TouchableOpacity,
   TextInput,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -59,7 +59,7 @@ export default function ChangeEmailScreen() {
 
   const handleSendCode = async () => {
     if (!newEmail.trim() || !currentPassword) {
-      Alert.alert(t('common.error'), t('validation.requiredFields'));
+      showAlert(t('common.error'), t('validation.requiredFields'));
       return;
     }
     setLoading(true);
@@ -70,7 +70,7 @@ export default function ChangeEmailScreen() {
       setPendingEmail(newEmail.trim());
       setStep(2);
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setLoading(false);
     }
@@ -78,7 +78,7 @@ export default function ChangeEmailScreen() {
 
   const handleConfirm = async () => {
     if (!code.trim()) {
-      Alert.alert(t('common.error'), t('validation.requiredFields'));
+      showAlert(t('common.error'), t('validation.requiredFields'));
       return;
     }
     setLoading(true);
@@ -87,13 +87,13 @@ export default function ChangeEmailScreen() {
       updateUser({ email: pendingEmail });
       setTokens(result.accessToken, result.refreshToken);
       await secureStorage.removeItem(PENDING_KEY);
-      Alert.alert(
+      showAlert(
         t('settings.changeEmail.success'),
         t('settings.changeEmail.successMessage'),
         [{ text: t('common.ok'), onPress: () => router.back() }],
       );
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setLoading(false);
     }

--- a/apps/mobile/app/settings/data.tsx
+++ b/apps/mobile/app/settings/data.tsx
@@ -5,9 +5,9 @@ import {
   ScrollView,
   TouchableOpacity,
   Switch,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -63,9 +63,9 @@ export default function DataSettingsScreen() {
       ]);
       const time = await getLastSyncTime();
       setLastSyncTimeState(time);
-      Alert.alert(t('common.success'), t('settings.syncComplete'));
+      showAlert(t('common.success'), t('settings.syncComplete'));
     } catch {
-      Alert.alert(t('common.error'), t('settings.syncFailed'));
+      showAlert(t('common.error'), t('settings.syncFailed'));
     } finally {
       setIsSyncing(false);
     }
@@ -85,7 +85,7 @@ export default function DataSettingsScreen() {
     try {
       await updateReportPrefs({ weeklyEmailEnabled: value });
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -93,7 +93,7 @@ export default function DataSettingsScreen() {
     try {
       await updateReportPrefs({ monthlyDigestEnabled: value });
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -101,7 +101,7 @@ export default function DataSettingsScreen() {
     try {
       await updateReportPrefs({ weeklyEmailDay: day });
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -109,14 +109,14 @@ export default function DataSettingsScreen() {
     try {
       const result = await exportBackup();
       if (result.status === 'saved') {
-        Alert.alert(t('common.success'), t('reports.backupSavedTo', { location: result.location }));
+        showAlert(t('common.success'), t('reports.backupSavedTo', { location: result.location }));
       } else if (result.status === 'shared') {
-        Alert.alert(t('common.success'), t('reports.backupShared'));
+        showAlert(t('common.success'), t('reports.backupShared'));
       } else {
-        Alert.alert(t('common.error'), result.error || t('errors.unknown'));
+        showAlert(t('common.error'), result.error || t('errors.unknown'));
       }
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -132,15 +132,15 @@ export default function DataSettingsScreen() {
       try {
         const parsed = JSON.parse(data);
         if (!parsed.version || !parsed.data) {
-          Alert.alert(t('common.error'), t('errors.unknown'));
+          showAlert(t('common.error'), t('errors.unknown'));
           return;
         }
       } catch {
-        Alert.alert(t('common.error'), t('errors.unknown'));
+        showAlert(t('common.error'), t('errors.unknown'));
         return;
       }
 
-      Alert.alert(
+      showAlert(
         t('reports.restoreConfirmTitle'),
         t('reports.restoreConfirmMerge'),
         [
@@ -149,7 +149,7 @@ export default function DataSettingsScreen() {
             text: t('reports.overwrite'),
             style: 'destructive',
             onPress: async () => {
-              Alert.alert(
+              showAlert(
                 t('reports.restoreConfirmTitle'),
                 t('reports.restoreConfirmOverwrite'),
                 [
@@ -160,9 +160,9 @@ export default function DataSettingsScreen() {
                     onPress: async () => {
                       const res = await restoreBackup(data, true);
                       if (res.errors.length === 0) {
-                        Alert.alert(t('common.success'), t('reports.backupRestored'));
+                        showAlert(t('common.success'), t('reports.backupRestored'));
                       } else {
-                        Alert.alert(t('common.error'), res.errors.join('\n'));
+                        showAlert(t('common.error'), res.errors.join('\n'));
                       }
                     },
                   },
@@ -175,16 +175,16 @@ export default function DataSettingsScreen() {
             onPress: async () => {
               const res = await restoreBackup(data, false);
               if (res.errors.length === 0) {
-                Alert.alert(t('common.success'), t('reports.backupRestored'));
+                showAlert(t('common.success'), t('reports.backupRestored'));
               } else {
-                Alert.alert(t('common.error'), res.errors.join('\n'));
+                showAlert(t('common.error'), res.errors.join('\n'));
               }
             },
           },
         ],
       );
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 

--- a/apps/mobile/app/settings/import/index.tsx
+++ b/apps/mobile/app/settings/import/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { View, Text, TouchableOpacity, FlatList, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
@@ -92,7 +93,7 @@ export default function ImportHubScreen() {
         copyToCacheDirectory: true,
       });
     } catch (err) {
-      Alert.alert(
+      showAlert(
         t('bankImport.error.parseFailed'),
         err instanceof Error ? err.message : String(err),
       );
@@ -122,7 +123,7 @@ export default function ImportHubScreen() {
       useImportStore.getState().setPreview(preview);
       router.push('/settings/import/preview');
     } catch (err) {
-      Alert.alert(
+      showAlert(
         t('bankImport.error.parseFailed'),
         err instanceof Error ? err.message : String(err),
       );
@@ -130,7 +131,7 @@ export default function ImportHubScreen() {
   };
 
   const deleteMapping = (m: CsvImportMapping) => {
-    Alert.alert(
+    showAlert(
       t('bankImport.deleteMapping'),
       t('bankImport.deleteMappingConfirm'),
       [
@@ -148,7 +149,7 @@ export default function ImportHubScreen() {
   };
 
   const handleUndo = (batch: ImportBatchDto) => {
-    Alert.alert(
+    showAlert(
       t('bankImport.undoImportTitle'),
       t('bankImport.undoImportConfirm', { count: batch.rowCount }),
       [
@@ -163,7 +164,7 @@ export default function ImportHubScreen() {
               await useIncomeStore.getState().loadIncomes({ force: true });
               loadBatches();
             } catch (err) {
-              Alert.alert(
+              showAlert(
                 t('common.error'),
                 err instanceof Error ? err.message : String(err),
               );

--- a/apps/mobile/app/settings/import/mapper.tsx
+++ b/apps/mobile/app/settings/import/mapper.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { View, Text, TouchableOpacity, ScrollView, Switch, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, Switch } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -68,7 +69,7 @@ export default function ColumnMapperScreen() {
       setPreview(res);
       router.replace('/settings/import/preview');
     } catch (err) {
-      Alert.alert(
+      showAlert(
         t('bankImport.error.parseFailed'),
         err instanceof Error ? err.message : String(err),
       );

--- a/apps/mobile/app/settings/import/preview.tsx
+++ b/apps/mobile/app/settings/import/preview.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, FlatList, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
@@ -59,7 +60,7 @@ export default function ImportPreviewScreen() {
                 const res = await api.importBankPreview(file, { bankId: b.id });
                 setPreview(res);
               } catch (err) {
-                Alert.alert(
+                showAlert(
                   t('bankImport.error.parseFailed'),
                   err instanceof Error ? err.message : String(err),
                 );
@@ -121,7 +122,7 @@ export default function ImportPreviewScreen() {
       await useExpenseStore.getState().loadExpenses({ force: true });
       await useIncomeStore.getState().loadIncomes({ force: true });
 
-      Alert.alert(
+      showAlert(
         t('common.done'),
         t('bankImport.summary', {
           expenses: result.createdExpenses,
@@ -131,7 +132,7 @@ export default function ImportPreviewScreen() {
         [{ text: t('common.ok'), onPress: () => router.replace('/settings') }],
       );
     } catch (err) {
-      Alert.alert(
+      showAlert(
         t('bankImport.error.parseFailed'),
         err instanceof Error ? err.message : String(err),
       );

--- a/apps/mobile/app/settings/import/request-bank.tsx
+++ b/apps/mobile/app/settings/import/request-bank.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -35,16 +36,16 @@ export default function RequestBankScreen() {
 
   const send = async () => {
     if (!bankName.trim()) {
-      Alert.alert(t('bankImport.requestErrorNoName'));
+      showAlert(t('bankImport.requestErrorNoName'));
       return;
     }
     setSending(true);
     try {
       await api.requestBank({ bankName: bankName.trim(), notes: notes.trim() || undefined, file: file ?? undefined });
-      Alert.alert(t('bankImport.requestSent'));
+      showAlert(t('bankImport.requestSent'));
       router.back();
     } catch (err) {
-      Alert.alert(t('bankImport.requestError'), err instanceof Error ? err.message : String(err));
+      showAlert(t('bankImport.requestError'), err instanceof Error ? err.message : String(err));
     } finally {
       setSending(false);
     }

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router } from 'expo-router';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -119,7 +120,7 @@ export default function SettingsIndexScreen() {
   ];
 
   const handleLogout = () => {
-    Alert.alert(
+    showAlert(
       t('settings.logout'),
       t('settings.logoutConfirm'),
       [

--- a/apps/mobile/app/settings/merchants.tsx
+++ b/apps/mobile/app/settings/merchants.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Alert, Modal, TextInput } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, Modal, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -36,23 +37,23 @@ export default function MerchantsSettingsScreen() {
   const handleSave = async () => {
     if (!editing) return;
     const next = name.trim();
-    if (!next) { Alert.alert(t('common.error'), t('merchants.nameRequired')); return; }
+    if (!next) { showAlert(t('common.error'), t('merchants.nameRequired')); return; }
     if (next === editing) { closeModal(); return; }
     setSaving(true);
     const count = await renameMerchant(editing, next);
     setSaving(false);
     closeModal();
-    Alert.alert('', t('merchants.renamed', { count }));
+    showAlert('', t('merchants.renamed', { count }));
   };
 
   const handleDelete = (merchant: string, count: number) => {
-    Alert.alert(t('merchants.delete'), t('merchants.deleteConfirm', { count }), [
+    showAlert(t('merchants.delete'), t('merchants.deleteConfirm', { count }), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('merchants.delete'), style: 'destructive',
         onPress: async () => {
           const n = await renameMerchant(merchant, null);
-          Alert.alert('', t('merchants.deleted', { count: n }));
+          showAlert('', t('merchants.deleted', { count: n }));
         },
       },
     ]);

--- a/apps/mobile/app/settings/notifications.tsx
+++ b/apps/mobile/app/settings/notifications.tsx
@@ -4,8 +4,8 @@ import {
   Text,
   ScrollView,
   Switch,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { useTheme, useStyles, type Theme } from '@/theme';
@@ -49,7 +49,7 @@ export default function NotificationsSettingsScreen() {
       await api.updateNotificationPreferences({ budgetAlerts: value });
     } catch (e) {
       setNotifBudgetAlerts(!value);
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -59,7 +59,7 @@ export default function NotificationsSettingsScreen() {
       await api.updateNotificationPreferences({ sharedAccountActivity: value });
     } catch (e) {
       setNotifSharedActivity(!value);
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -69,7 +69,7 @@ export default function NotificationsSettingsScreen() {
       await api.updateNotificationPreferences({ debtReminders: value });
     } catch (e) {
       setNotifDebtReminders(!value);
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -79,7 +79,7 @@ export default function NotificationsSettingsScreen() {
       await api.updateNotificationPreferences({ recurringExpenses: value });
     } catch (e) {
       setNotifRecurringExpenses(!value);
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -89,7 +89,7 @@ export default function NotificationsSettingsScreen() {
       await api.updateNotificationPreferences({ subscriptionRenewals: value });
     } catch (e) {
       setNotifSubscriptionRenewals(!value);
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -107,7 +107,7 @@ export default function NotificationsSettingsScreen() {
       setNotifDebtReminders(!value);
       setNotifRecurringExpenses(!value);
       setNotifSubscriptionRenewals(!value);
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 

--- a/apps/mobile/app/settings/profile.tsx
+++ b/apps/mobile/app/settings/profile.tsx
@@ -6,8 +6,8 @@ import {
   TextInput,
   Modal,
   FlatList,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { router } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -72,7 +72,7 @@ export default function ProfileSettingsScreen() {
   const handleSaveName = async () => {
     const trimmed = name.trim();
     if (!trimmed || trimmed.length < 2) {
-      Alert.alert(t('common.error'), t('validation.nameMin2'));
+      showAlert(t('common.error'), t('validation.nameMin2'));
       return;
     }
     setIsSaving(true);
@@ -80,9 +80,9 @@ export default function ProfileSettingsScreen() {
       await api.updateProfile({ name: trimmed });
       updateUser({ name: trimmed });
       setEditingName(false);
-      Alert.alert(t('common.success'), t('settings.profileUpdated'));
+      showAlert(t('common.success'), t('settings.profileUpdated'));
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setIsSaving(false);
     }
@@ -103,9 +103,9 @@ export default function ProfileSettingsScreen() {
       await api.updateProfile({ timezone });
       updateUser({ timezone });
       setTimezonePicker(false);
-      Alert.alert(t('common.success'), t('settings.timezoneUpdated'));
+      showAlert(t('common.success'), t('settings.timezoneUpdated'));
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 

--- a/apps/mobile/app/settings/security.tsx
+++ b/apps/mobile/app/settings/security.tsx
@@ -5,9 +5,9 @@ import {
   TouchableOpacity,
   TextInput,
   Modal,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -47,11 +47,11 @@ export default function SecuritySettingsScreen() {
 
   const handleSetupE2EE = async () => {
     if (e2eePassphrase.length < 8) {
-      Alert.alert(t('common.error'), t('encryption.passphraseMin'));
+      showAlert(t('common.error'), t('encryption.passphraseMin'));
       return;
     }
     if (e2eePassphrase !== e2eePassphraseConfirm) {
-      Alert.alert(t('common.error'), t('encryption.passphraseMismatch'));
+      showAlert(t('common.error'), t('encryption.passphraseMismatch'));
       return;
     }
     try {
@@ -68,7 +68,7 @@ export default function SecuritySettingsScreen() {
       setShowE2EESetup(false);
       setShowRecoveryKey(recoveryKey);
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     }
   };
 
@@ -85,10 +85,10 @@ export default function SecuritySettingsScreen() {
       }
       setE2eePassphrase('');
       setShowE2EEUnlock(false);
-      Alert.alert(t('common.success'), t('encryption.unlocked'));
+      showAlert(t('common.success'), t('encryption.unlocked'));
     } catch (e) {
       const msg = e instanceof Error ? e.message : '';
-      Alert.alert(
+      showAlert(
         t('common.error'),
         t('encryption.unlockFailed') + (msg ? `\n\n${msg}` : ''),
       );
@@ -96,7 +96,7 @@ export default function SecuritySettingsScreen() {
   };
 
   const handleResetE2EE = () => {
-    Alert.alert(
+    showAlert(
       t('encryption.resetTitle'),
       t('encryption.resetConfirm'),
       [
@@ -107,9 +107,9 @@ export default function SecuritySettingsScreen() {
           onPress: async () => {
             try {
               await resetE2EE();
-              Alert.alert(t('common.success'), t('encryption.resetSuccess'));
+              showAlert(t('common.success'), t('encryption.resetSuccess'));
             } catch (e) {
-              Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+              showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
             }
           },
         },
@@ -120,7 +120,7 @@ export default function SecuritySettingsScreen() {
   const handleCopyRecoveryKey = async () => {
     if (showRecoveryKey) {
       await Clipboard.setStringAsync(showRecoveryKey);
-      Alert.alert(t('common.success'), t('encryption.recoveryKeyCopied'));
+      showAlert(t('common.success'), t('encryption.recoveryKeyCopied'));
     }
   };
 

--- a/apps/mobile/app/settings/wise-import.tsx
+++ b/apps/mobile/app/settings/wise-import.tsx
@@ -5,8 +5,8 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   FlatList,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
@@ -59,13 +59,13 @@ export default function WiseImportScreen() {
         setScreenState('preview');
       } catch (err) {
         setScreenState('idle');
-        Alert.alert(
+        showAlert(
           t('wiseImport.error.parseFailed'),
           err instanceof Error ? err.message : String(err),
         );
       }
     } catch (err) {
-      Alert.alert(
+      showAlert(
         t('wiseImport.error.parseFailed'),
         err instanceof Error ? err.message : String(err),
       );
@@ -103,7 +103,7 @@ export default function WiseImportScreen() {
       setScreenState('done');
     } catch (err) {
       setScreenState('preview');
-      Alert.alert(
+      showAlert(
         t('wiseImport.error.parseFailed'),
         err instanceof Error ? err.message : String(err),
       );

--- a/apps/mobile/app/subscription.tsx
+++ b/apps/mobile/app/subscription.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { router } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -78,7 +79,7 @@ export default function SubscriptionScreen() {
       await loadSubscription();
       await loadUsage();
       if (result.type === 'success') {
-        Alert.alert(
+        showAlert(
           t('subscription.upgraded'),
           t('subscription.upgradeSuccess'),
         );

--- a/apps/mobile/app/subscriptions/[id].tsx
+++ b/apps/mobile/app/subscriptions/[id].tsx
@@ -5,10 +5,10 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
   Switch,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -61,12 +61,12 @@ export default function SubscriptionDetailScreen() {
 
   const handleSave = async () => {
     if (!name.trim()) {
-      Alert.alert(t('common.error'), t('subscriptionManager.errorName'));
+      showAlert(t('common.error'), t('subscriptionManager.errorName'));
       return;
     }
     const amountNum = parseFloat(amount.replace(',', '.'));
     if (isNaN(amountNum) || amountNum <= 0) {
-      Alert.alert(t('common.error'), t('subscriptionManager.errorAmount'));
+      showAlert(t('common.error'), t('subscriptionManager.errorAmount'));
       return;
     }
     setSaving(true);
@@ -81,14 +81,14 @@ export default function SubscriptionDetailScreen() {
       });
       router.back();
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setSaving(false);
     }
   };
 
   const handleDelete = () => {
-    Alert.alert(
+    showAlert(
       t('subscriptionManager.deleteTitle'),
       t('subscriptionManager.deleteMessage', { name: sub.name }),
       [
@@ -99,7 +99,7 @@ export default function SubscriptionDetailScreen() {
           onPress: () =>
             deleteSubscription(id)
               .then(() => router.back())
-              .catch(() => Alert.alert(t('common.error'), t('errors.unknown'))),
+              .catch(() => showAlert(t('common.error'), t('errors.unknown'))),
         },
       ],
     );

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -5,9 +5,9 @@ import {
   TouchableOpacity,
   FlatList,
   RefreshControl,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -60,7 +60,7 @@ export default function SubscriptionsScreen() {
 
   const handleDelete = useCallback(
     (sub: UserSubscription) => {
-      Alert.alert(
+      showAlert(
         t('subscriptionManager.deleteTitle'),
         t('subscriptionManager.deleteMessage', { name: sub.name }),
         [
@@ -68,7 +68,7 @@ export default function SubscriptionsScreen() {
           {
             text: t('common.delete'),
             style: 'destructive',
-            onPress: () => deleteSubscription(sub.id).catch(() => Alert.alert(t('common.error'), t('errors.unknown'))),
+            onPress: () => deleteSubscription(sub.id).catch(() => showAlert(t('common.error'), t('errors.unknown'))),
           },
         ],
       );

--- a/apps/mobile/app/subscriptions/new.tsx
+++ b/apps/mobile/app/subscriptions/new.tsx
@@ -5,9 +5,9 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
   ActivityIndicator,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -48,12 +48,12 @@ export default function NewSubscriptionScreen() {
 
   const handleSave = async () => {
     if (!name.trim()) {
-      Alert.alert(t('common.error'), t('subscriptionManager.errorName'));
+      showAlert(t('common.error'), t('subscriptionManager.errorName'));
       return;
     }
     const amountNum = parseFloat(amount.replace(',', '.'));
     if (isNaN(amountNum) || amountNum <= 0) {
-      Alert.alert(t('common.error'), t('subscriptionManager.errorAmount'));
+      showAlert(t('common.error'), t('subscriptionManager.errorAmount'));
       return;
     }
 
@@ -70,7 +70,7 @@ export default function NewSubscriptionScreen() {
       });
       router.back();
     } catch (e) {
-      Alert.alert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
+      showAlert(t('common.error'), e instanceof Error ? e.message : t('errors.unknown'));
     } finally {
       setSaving(false);
     }

--- a/apps/mobile/app/tags/manage.tsx
+++ b/apps/mobile/app/tags/manage.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import {
-  View, Text, ScrollView, TouchableOpacity, Alert, Modal, TextInput,
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Modal,
+  TextInput,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { Stack } from 'expo-router';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -75,7 +81,7 @@ export default function ManageTagsScreen() {
   };
 
   const handleDelete = (tag: Tag) => {
-    Alert.alert(t('tags.deleteTag'), t('tags.confirmDelete'), [
+    showAlert(t('tags.deleteTag'), t('tags.confirmDelete'), [
       { text: t('common.cancel'), style: 'cancel' },
       { text: t('common.delete'), style: 'destructive', onPress: () => deleteTag(tag.id) },
     ]);

--- a/apps/mobile/app/wallet/[id].tsx
+++ b/apps/mobile/app/wallet/[id].tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { View, Text, TouchableOpacity, TextInput, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -48,7 +49,7 @@ export default function TransferDetailScreen() {
     const rate = parseFloat(editExchangeRate);
 
     if (!from || !to || !rate || from <= 0 || to <= 0 || rate <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
@@ -72,7 +73,7 @@ export default function TransferDetailScreen() {
   };
 
   const handleDelete = () => {
-    Alert.alert(t('transfer.deleteTitle'), t('transfer.deleteConfirm'), [
+    showAlert(t('transfer.deleteTitle'), t('transfer.deleteConfirm'), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/wallet/exchange/[id].tsx
+++ b/apps/mobile/app/wallet/exchange/[id].tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { View, Text, TouchableOpacity, TextInput, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -44,7 +45,7 @@ export default function ExchangeDetailScreen() {
     const rate = parseFloat(editExchangeRate);
 
     if (!from || !to || !rate || from <= 0 || to <= 0 || rate <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
@@ -66,7 +67,7 @@ export default function ExchangeDetailScreen() {
   };
 
   const handleDelete = () => {
-    Alert.alert(t('exchange.deleteTitle'), t('exchange.deleteConfirm'), [
+    showAlert(t('exchange.deleteTitle'), t('exchange.deleteConfirm'), [
       { text: t('common.cancel'), style: 'cancel' },
       {
         text: t('common.delete'),

--- a/apps/mobile/app/wallet/exchange/index.tsx
+++ b/apps/mobile/app/wallet/exchange/index.tsx
@@ -1,4 +1,5 @@
-import { View, Text, ScrollView, TouchableOpacity, TextInput, Alert } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { useState, useEffect } from 'react';
 import { router, Stack } from 'expo-router';
@@ -94,7 +95,7 @@ export default function ExchangeScreen() {
 
   const handleSubmit = () => {
     if (fromCurrency === toCurrency) {
-      Alert.alert(t('common.error'), t('exchange.sameCurrencyError'));
+      showAlert(t('common.error'), t('exchange.sameCurrencyError'));
       return;
     }
 
@@ -103,7 +104,7 @@ export default function ExchangeScreen() {
     const rate = parseFloat(exchangeRate);
 
     if (!from || !to || !rate || from <= 0 || to <= 0 || rate <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 

--- a/apps/mobile/app/wallet/set-balance.tsx
+++ b/apps/mobile/app/wallet/set-balance.tsx
@@ -1,4 +1,5 @@
-import { View, Text, TouchableOpacity, TextInput, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { useState, useEffect, useMemo } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -41,18 +42,18 @@ export default function SetBalanceScreen() {
   const handleSave = () => {
     const parsedAmount = parseFloat(amount);
     if (isNaN(parsedAmount) || parsedAmount < 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 
     if (isEditMode && editingBalance) {
       updateInitialBalance(editingBalance.id, parsedAmount);
       router.setParams({ editId: '' });
-      Alert.alert(t('common.success'), t('wallet.balanceUpdated'));
+      showAlert(t('common.success'), t('wallet.balanceUpdated'));
     } else {
       setInitialBalance(selectedCurrency, parsedAmount);
       setAmount('');
-      Alert.alert(t('common.success'), t('wallet.balanceSaved'));
+      showAlert(t('common.success'), t('wallet.balanceSaved'));
     }
   };
 
@@ -65,7 +66,7 @@ export default function SetBalanceScreen() {
   };
 
   const handleDelete = (id: string, currencyCode: string) => {
-    Alert.alert(
+    showAlert(
       t('wallet.deleteBalance'),
       t('wallet.deleteConfirm'),
       [

--- a/apps/mobile/app/wallet/transfer.tsx
+++ b/apps/mobile/app/wallet/transfer.tsx
@@ -1,4 +1,5 @@
-import { View, Text, ScrollView, TouchableOpacity, TextInput, Alert } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, TextInput } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAwareScreen } from '@/components/KeyboardAwareScreen';
 import { useState, useEffect } from 'react';
 import { router, Stack } from 'expo-router';
@@ -101,11 +102,11 @@ export default function TransferScreen() {
 
   const handleSubmit = () => {
     if (!fromAccountId || !toAccountId) {
-      Alert.alert(t('common.error'), t('transfer.sameAccountError'));
+      showAlert(t('common.error'), t('transfer.sameAccountError'));
       return;
     }
     if (fromAccountId === toAccountId) {
-      Alert.alert(t('common.error'), t('transfer.sameAccountError'));
+      showAlert(t('common.error'), t('transfer.sameAccountError'));
       return;
     }
 
@@ -114,7 +115,7 @@ export default function TransferScreen() {
     const rate = parseFloat(exchangeRate);
 
     if (!from || !to || !rate || from <= 0 || to <= 0 || rate <= 0) {
-      Alert.alert(t('common.error'), t('validation.invalidAmount'));
+      showAlert(t('common.error'), t('validation.invalidAmount'));
       return;
     }
 

--- a/apps/mobile/src/components/CreateCategoryModal.tsx
+++ b/apps/mobile/src/components/CreateCategoryModal.tsx
@@ -5,8 +5,8 @@ import {
   TextInput,
   TouchableOpacity,
   Modal,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
@@ -44,7 +44,7 @@ export const CreateCategoryModal: React.FC<CreateCategoryModalProps> = ({
   const handleCreate = async () => {
     const trimmed = name.trim();
     if (!trimmed) {
-      Alert.alert(t('common.error'), t('categoryCreate.nameRequired'));
+      showAlert(t('common.error'), t('categoryCreate.nameRequired'));
       return;
     }
 
@@ -55,7 +55,7 @@ export const CreateCategoryModal: React.FC<CreateCategoryModalProps> = ({
       setSelectedColor(PRESET_COLORS[0]);
       onCreated(category.id);
     } catch {
-      Alert.alert(t('common.error'), t('errors.saveFailed'));
+      showAlert(t('common.error'), t('errors.saveFailed'));
     } finally {
       setIsCreating(false);
     }

--- a/apps/mobile/src/components/ProjectPicker.tsx
+++ b/apps/mobile/src/components/ProjectPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { router } from 'expo-router';
@@ -22,7 +23,7 @@ export const ProjectPicker: React.FC<ProjectPickerProps> = ({
   );
 
   const handleDeleteProject = (projectId: string, projectName: string) => {
-    Alert.alert(
+    showAlert(
       t('projects.deleteProject') || 'Delete Project',
       t('projects.confirmDelete') || 'Are you sure you want to delete this project?',
       [

--- a/apps/mobile/src/components/SplitEditor.tsx
+++ b/apps/mobile/src/components/SplitEditor.tsx
@@ -5,11 +5,11 @@ import {
   TouchableOpacity,
   TextInput,
   StyleSheet,
-  Alert,
   Modal,
   Pressable,
   ScrollView,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { useCategoryStore } from '../stores/categoryStore';
@@ -103,14 +103,14 @@ export const SplitEditor: React.FC<SplitEditorProps> = ({
   const handleConfirm = useCallback(() => {
     const total = splits.reduce((sum, s) => sum + s.amount, 0);
     if (Math.abs(total - totalAmount) > 0.01) {
-      Alert.alert(
+      showAlert(
         t('splits.totalMustMatch') || 'Total must match',
         `Split total: ${total.toFixed(2)}, Expense: ${totalAmount.toFixed(2)}`,
       );
       return;
     }
     if (splits.length < 2) {
-      Alert.alert('', t('splits.addCategory') || 'Add at least 2 categories');
+      showAlert('', t('splits.addCategory') || 'Add at least 2 categories');
       return;
     }
     // Strip the internal display-only field before handing splits to the parent.

--- a/apps/mobile/src/components/TagPicker.tsx
+++ b/apps/mobile/src/components/TagPicker.tsx
@@ -6,8 +6,8 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   StyleSheet,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { TagChip } from './TagChip';
@@ -33,7 +33,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
 
   const handleSuggestPress = useCallback(async () => {
     if (!description || description.length < 3) {
-      Alert.alert(t('tags.suggestTags'), t('tags.descriptionRequired') || 'Enter a description first (at least 3 characters)');
+      showAlert(t('tags.suggestTags'), t('tags.descriptionRequired') || 'Enter a description first (at least 3 characters)');
       return;
     }
     setIsLoadingSuggestions(true);
@@ -44,7 +44,7 @@ export const TagPicker: React.FC<TagPickerProps> = ({
       }
     } catch (e: any) {
       console.error('[TagPicker] suggestTags error:', e?.message || e);
-      Alert.alert(t('tags.suggestTags'), e?.message || 'Failed to load suggestions');
+      showAlert(t('tags.suggestTags'), e?.message || 'Failed to load suggestions');
     } finally {
       setIsLoadingSuggestions(false);
     }

--- a/apps/mobile/src/components/budget/BudgetEditForm.tsx
+++ b/apps/mobile/src/components/budget/BudgetEditForm.tsx
@@ -5,8 +5,8 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
-  Alert,
 } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { KeyboardAvoidingScreen as KeyboardAvoidingView } from '@/components/KeyboardAvoidingScreen';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -81,7 +81,7 @@ export function BudgetEditForm({ budget, onSaved, onCancel }: BudgetEditFormProp
 
   const handleSave = () => {
     if (!editName.trim()) {
-      Alert.alert(t('common.error'), t('budgetNew.errorName'));
+      showAlert(t('common.error'), t('budgetNew.errorName'));
       return;
     }
 
@@ -89,12 +89,12 @@ export function BudgetEditForm({ budget, onSaved, onCancel }: BudgetEditFormProp
     const numericAmount = editBudgetMode === 'byCategory' ? totalFromAllocations : parseFloat(editAmount);
 
     if (!numericAmount || numericAmount <= 0) {
-      Alert.alert(t('common.error'), t('budgetNew.errorAmount'));
+      showAlert(t('common.error'), t('budgetNew.errorAmount'));
       return;
     }
 
     if (editBudgetMode === 'byCategory' && editCategoryAllocations.length === 0) {
-      Alert.alert(t('common.error'), t('budgetNew.errorNoCategories'));
+      showAlert(t('common.error'), t('budgetNew.errorNoCategories'));
       return;
     }
 

--- a/apps/mobile/src/components/chat/ChatMessageItem.tsx
+++ b/apps/mobile/src/components/chat/ChatMessageItem.tsx
@@ -1,4 +1,5 @@
-import { View, Text, TouchableOpacity, Alert, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { Ionicons } from '@expo/vector-icons';
 import Markdown from 'react-native-markdown-display';
 import * as Clipboard from 'expo-clipboard';
@@ -88,7 +89,7 @@ export function ChatMessageItem({
 
   const handleLongPress = () => {
     const preview = item.content.length > 80 ? item.content.slice(0, 80) + '…' : item.content;
-    Alert.alert('', preview, [
+    showAlert('', preview, [
       { text: t('common.copy'), onPress: () => Clipboard.setStringAsync(item.content) },
       { text: t('common.cancel'), style: 'cancel' },
     ]);

--- a/apps/mobile/src/hooks/useAiCostConfirmation.ts
+++ b/apps/mobile/src/hooks/useAiCostConfirmation.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { Alert } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { useTranslation } from 'react-i18next';
 import { MMKV } from 'react-native-mmkv';
 import { useSubscriptionStore } from '@/stores/subscriptionStore';
@@ -31,7 +31,7 @@ export function useAiCostConfirmation() {
       const currentT = tRef.current;
 
       return new Promise((resolve) => {
-        Alert.alert(
+        showAlert(
           currentT('aiUsage.confirmTitle'),
           currentT('aiUsage.confirmMessage', {
             cost: costCredits,

--- a/apps/mobile/src/hooks/useExpenseMultiSelect.ts
+++ b/apps/mobile/src/hooks/useExpenseMultiSelect.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Alert } from 'react-native';
+import { showAlert } from '@/utils/alert';
 import { useTranslation } from 'react-i18next';
 import type { Expense } from '@budget/shared-types';
 
@@ -53,7 +53,7 @@ export function useExpenseMultiSelect(
     setIsBulkProcessing(true);
     try {
       await bulkUpdateExpenses(Array.from(selectedIds), { categoryId });
-      Alert.alert('', t('expenses.bulkCategoryApplied', { count: selectedIds.size }));
+      showAlert('', t('expenses.bulkCategoryApplied', { count: selectedIds.size }));
       exitMultiSelect();
     } finally {
       setIsBulkProcessing(false);
@@ -66,7 +66,7 @@ export function useExpenseMultiSelect(
     setIsBulkProcessing(true);
     try {
       await bulkUpdateExpenses(Array.from(selectedIds), { tagIds });
-      Alert.alert('', t('expenses.bulkTagsApplied', { count: selectedIds.size }));
+      showAlert('', t('expenses.bulkTagsApplied', { count: selectedIds.size }));
       exitMultiSelect();
     } finally {
       setIsBulkProcessing(false);
@@ -75,7 +75,7 @@ export function useExpenseMultiSelect(
 
   const handleBulkDelete = () => {
     if (selectedIds.size === 0) return;
-    Alert.alert(
+    showAlert(
       t('expenses.bulkDeleteConfirm', { count: selectedIds.size }),
       t('expenses.bulkDeleteConfirmMessage'),
       [
@@ -87,7 +87,7 @@ export function useExpenseMultiSelect(
             setIsBulkProcessing(true);
             try {
               await bulkUpdateExpenses(Array.from(selectedIds), { isDeleted: true });
-              Alert.alert('', t('expenses.bulkDeleted', { count: selectedIds.size }));
+              showAlert('', t('expenses.bulkDeleted', { count: selectedIds.size }));
               exitMultiSelect();
             } finally {
               setIsBulkProcessing(false);

--- a/apps/mobile/src/utils/alert.ts
+++ b/apps/mobile/src/utils/alert.ts
@@ -1,0 +1,52 @@
+import { Alert, Platform, type AlertButton, type AlertOptions } from 'react-native';
+
+/**
+ * Cross-platform alert.
+ *
+ * react-native-web (0.21) ships a stubbed `Alert` whose `alert()` is a complete
+ * no-op (`class Alert { static alert() {} }`). That means every `Alert.alert(...)`
+ * call silently does nothing on the web build — validation messages never show,
+ * and buttons that rely on an alert for feedback (e.g. "Save expense" when a
+ * required field is empty) appear completely dead. This wrapper falls back to the
+ * browser's native `window.alert` / `window.confirm` on web while delegating to
+ * the real native `Alert.alert` everywhere else.
+ *
+ * Use this instead of `Alert.alert` for any user-facing notice or confirmation
+ * that must work on web.
+ */
+export function showAlert(
+  title: string,
+  message?: string,
+  buttons?: AlertButton[],
+  options?: AlertOptions,
+): void {
+  if (Platform.OS !== 'web') {
+    Alert.alert(title, message, buttons, options);
+    return;
+  }
+
+  const text = [title, message].filter(Boolean).join('\n\n');
+
+  // Simple notice (no buttons, or a single acknowledgement button).
+  if (!buttons || buttons.length === 0) {
+    window.alert(text);
+    return;
+  }
+
+  if (buttons.length === 1) {
+    window.alert(text);
+    buttons[0]?.onPress?.();
+    return;
+  }
+
+  // Confirmation: map OK/Cancel onto window.confirm.
+  const cancelButton = buttons.find((b) => b.style === 'cancel');
+  const confirmButton =
+    buttons.find((b) => b.style !== 'cancel') ?? buttons[buttons.length - 1];
+
+  if (window.confirm(text)) {
+    confirmButton?.onPress?.();
+  } else {
+    cancelButton?.onPress?.();
+  }
+}


### PR DESCRIPTION
## Problem

On the **web** build, tapping **Save** in the new-expense form did nothing — no dialog, no feedback, button looked dead.

Root cause: `react-native-web` 0.21 ships a stubbed `Alert` whose `alert()` is a complete no-op:

```js
class Alert { static alert() {} }
```

So **every** `Alert.alert(...)` call silently does nothing on web. In the expense/income forms the required-field validation and the error path all went through `Alert.alert`, so an empty required field (or a save failure) produced zero feedback.

## Fix

- New web-safe helper `apps/mobile/src/utils/alert.ts` → `showAlert(...)`:
  - native: delegates to `Alert.alert` (unchanged behaviour)
  - web: falls back to `window.alert` (notices) / `window.confirm` (2-button confirmations — OK maps to the non-cancel button, Cancel to the `style: 'cancel'` button)
- Replaced **all 214 `Alert.alert` call sites across 60 files** with `showAlert`, removed the now-unused `Alert` imports from `react-native`.

## Scope

Expense/income forms, budgets, goals, accounts, wallet, investments, subscriptions, import (Wise/banks), settings (profile, security, change-email, data), chat, tags/projects/categories, reports, etc.

## Verification

- ✅ No `Alert.alert` left in code
- ✅ No dangling bare `Alert` code references (only comments / help content / i18n strings remain, not code)
- ✅ All 62 files using `showAlert` have the import; no duplicates
- ✅ Import blocks (multi-line and single-line) intact; no empty `import { } from 'react-native'`
- ✅ `@` → `src` alias resolves in both babel (runtime) and tsconfig (typecheck)

Note: full `tsc`/lint not run — the environment has no installed `node_modules`. Changes are mechanical and verified textually.

https://claude.ai/code/session_01MV2ZBVmmXTr44bP42fo511

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV2ZBVmmXTr44bP42fo511)_