### PR TITLE
fix(mobile/web): expenses & incomes not displaying on web (re-hydrate wipe)

### DIFF
--- a/apps/mobile/src/stores/expenseStore.ts
+++ b/apps/mobile/src/stores/expenseStore.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import type { Expense, ExpenseItem, ExpenseCategorySplit, SyncStatus, Currency } from '@budget/shared-types';
@@ -154,7 +155,20 @@ export const useExpenseStore = create<ExpenseState>()(
           if (pid) exp.projectId = pid;
         }
 
-        set({ expenses: localExpenses, isLoading: false });
+        // On web SQLite is a no-op mock, so `localExpenses` is ALWAYS empty.
+        // Blindly setting it here wipes the in-memory rows a previous server
+        // pull populated; combined with the sync-skip early-return below, the
+        // list would then stay blank on every re-hydrate within the skip window
+        // (e.g. switching to the Expenses tab) — which is why nothing showed on
+        // web. Only clobber when the local read has data, or when the in-memory
+        // rows belong to a DIFFERENT account (so account-switch still clears).
+        const inMemorySameAccount =
+          get().expenses.length === 0 || get().expenses[0].accountId === accountId;
+        if (Platform.OS !== 'web' || localExpenses.length > 0 || !inMemorySameAccount) {
+          set({ expenses: localExpenses, isLoading: false });
+        } else {
+          set({ isLoading: false });
+        }
 
         // Skip server-pull if we synced recently for this account (unless forced).
         // Pull-to-refresh passes force:true to bypass.

--- a/apps/mobile/src/stores/incomeStore.ts
+++ b/apps/mobile/src/stores/incomeStore.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import type { Income, Currency, IncomeSource, SyncStatus } from '@budget/shared-types';
@@ -119,7 +120,21 @@ export const useIncomeStore = create<IncomeState>()(
         // 1. Show local data immediately
         const localIncomes = await loadAllIncomes(accountId);
         if (useAccountStore.getState().currentAccountId !== accountId) return;
-        set({ incomes: localIncomes, isLoading: false });
+
+        // On web SQLite is a no-op mock, so `localIncomes` is ALWAYS empty.
+        // Blindly setting it here wipes the in-memory rows a previous server
+        // pull populated; combined with the sync-skip early-return below, the
+        // list would then stay blank on every re-hydrate within the skip window
+        // (e.g. switching to the Income tab) — which is why nothing showed on
+        // web. Only clobber when the local read has data, or when the in-memory
+        // rows belong to a DIFFERENT account (so account-switch still clears).
+        const inMemorySameAccount =
+          get().incomes.length === 0 || get().incomes[0].accountId === accountId;
+        if (Platform.OS !== 'web' || localIncomes.length > 0 || !inMemorySameAccount) {
+          set({ incomes: localIncomes, isLoading: false });
+        } else {
+          set({ isLoading: false });
+        }
 
         // Skip server-pull if we synced recently for this account (unless forced).
         const msSinceLastSync = Date.now() - _lastIncomesSyncAt;


### PR DESCRIPTION
## Problem

On the **web** build, expenses and incomes (and the dashboard totals derived from them) showed up blank.

Root cause: on web, SQLite is a no-op mock, so `loadAllExpenses` / `loadAllIncomes` always return `[]`. In `loadExpenses` / `loadIncomes` the flow is:

1. Read locally (web → `[]`) and **immediately** `set({ expenses: localRows })`.
2. If synced recently (30s skip window), **return before the server re-pull**.

Cold boot fires `hydrateTransactions()` twice in quick succession — first from `authStore` (on login), then from each tab's `useEffect` on mount. The first call pulls data from the server, renders it, and stamps the skip-window timestamp. The second call (within the window) **overwrites the in-memory rows with the empty local read and returns early**, leaving the lists permanently blank on web.

On native this never happens — the local read returns real rows.

## Fix

In both `expenseStore` and `incomeStore`: on web, **don't clobber** the in-memory rows with an empty local read when those rows already belong to the current account.

- **Native** — unchanged (local read returns real rows; the `Platform.OS !== 'web'` branch always sets).
- **Account switch** — still clears: in-memory rows belong to a different `accountId`, so the old behavior runs and the server pull repopulates (a switched account is never "recent").
- **Pull-to-refresh** (`force: true`) and post-30s navigation re-pull as before.

```ts
const inMemorySameAccount =
  get().expenses.length === 0 || get().expenses[0].accountId === accountId;
if (Platform.OS !== 'web' || localExpenses.length > 0 || !inMemorySameAccount) {
  set({ expenses: localExpenses, isLoading: false });
} else {
  set({ isLoading: false });
}
```

## Notes

- Same anti-pattern (clobber with empty local read) exists in other stores (wallet, budgets, …) and may cause similar web flicker after navigation — scoped this PR to the reported expenses/incomes per request.
- Full `tsc`/lint not run — the environment has no installed `node_modules`. Change is small and within existing patterns.

https://claude.ai/code/session_01MV2ZBVmmXTr44bP42fo511

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV2ZBVmmXTr44bP42fo511)_