### PR TITLE
fix(mobile-web): keep bottom tab bar visible on mobile browsers

### DIFF
--- a/apps/mobile/app/+html.tsx
+++ b/apps/mobile/app/+html.tsx
@@ -1,0 +1,51 @@
+import { ScrollViewStyleReset } from 'expo-router/html';
+import { type PropsWithChildren } from 'react';
+
+/**
+ * Web-only root HTML document. This file is used ONLY by the Expo web export
+ * (`expo export --platform web`) to wrap every page; native iOS/Android builds
+ * ignore it entirely.
+ *
+ * Mobile-web bottom-cutoff fix: the app root used to fill `100vh`, which on
+ * mobile browsers is the *large* viewport (as tall as if the URL bar were
+ * retracted). While the URL bar / system navigation bar is visible the page is
+ * therefore taller than the visible area, so the bottom tab bar fell below the
+ * fold and looked clipped. We pin the root to the *dynamic* viewport height
+ * (`100dvh`) so the layout always fits the currently-visible viewport, and add
+ * `viewport-fit=cover` so iOS Safari safe-area insets (home indicator) resolve
+ * via react-native-safe-area-context.
+ */
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+        />
+        {/*
+          Disable body scrolling on web so the app's own ScrollViews handle it.
+          Must come BEFORE our height override so source order keeps `100dvh`.
+        */}
+        <ScrollViewStyleReset />
+        <style dangerouslySetInnerHTML={{ __html: viewportFixStyle }} />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+
+// Use the dynamic viewport height where supported so the bottom tab bar is
+// never hidden behind the browser URL bar or the system navigation bar. Falls
+// back to `100%` (the ScrollViewStyleReset default) on older browsers.
+const viewportFixStyle = `
+@supports (height: 100dvh) {
+  html,
+  body,
+  #root {
+    height: 100dvh;
+  }
+}
+`;


### PR DESCRIPTION
## Problem

On the web build (https://ai-budget.pl) viewed from a phone, the bottom tab bar (Pulpit / Transakcje / Budżet / Analityka / Czat AI) is clipped behind the browser URL bar / system navigation bar.

**Root cause:** the app root filled `100vh`. On mobile browsers `100vh` is the *large* viewport (as tall as if the URL bar were retracted), so while the browser/system nav bar is visible the page is taller than the visible area and the bottom tab bar falls below the fold. Additionally `insets.bottom` from `react-native-safe-area-context` was `0` on web because `viewport-fit=cover` was never set.

## Fix

Add a **web-only** `apps/mobile/app/+html.tsx` root document (used only by `expo export --platform web`; native iOS/Android builds ignore it entirely):

1. Pins `html/body/#root` to the **dynamic** viewport height (`100dvh`, with a `100%` fallback via `@supports`) so the layout always fits the currently-visible viewport.
2. Sets `viewport-fit=cover` so iOS Safari safe-area insets resolve via `react-native-safe-area-context` (already consumed by `(tabs)/_layout.tsx`).

## Scope / safety

- **Native unaffected:** `+html.tsx` is an Expo Router web-only convention — it is not a route and is never included in the native bundle.
- No changes to the tab bar layout code, stores, or any shared logic.
- Auto-deploys to https://ai-budget.pl via `web-deploy.yml` on merge to `development`.

## Note

I could not build the web bundle locally because dependencies are not installed in this environment (`npm install` was never run). `+html.tsx` and `ScrollViewStyleReset` are stable expo-router v6 (SDK 54) APIs, and the file follows the official template.

https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM

---
_Generated by [Claude Code](https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM)_