### PR TITLE
fix(mobile-web): apply safe-area inset so bottom tab bar clears the nav bar

### DIFF
--- a/apps/mobile/app/+html.tsx
+++ b/apps/mobile/app/+html.tsx
@@ -6,14 +6,21 @@ import { type PropsWithChildren } from 'react';
  * (`expo export --platform web`) to wrap every page; native iOS/Android builds
  * ignore it entirely.
  *
- * Mobile-web bottom-cutoff fix: the app root used to fill `100vh`, which on
- * mobile browsers is the *large* viewport (as tall as if the URL bar were
- * retracted). While the URL bar / system navigation bar is visible the page is
- * therefore taller than the visible area, so the bottom tab bar fell below the
- * fold and looked clipped. We pin the root to the *dynamic* viewport height
- * (`100dvh`) so the layout always fits the currently-visible viewport, and add
- * `viewport-fit=cover` so iOS Safari safe-area insets (home indicator) resolve
- * via react-native-safe-area-context.
+ * Mobile-web bottom-cutoff fix. Two things were clipping the bottom tab bar:
+ *
+ *  1. `100vh` is the *large* viewport on mobile browsers (as tall as if the URL
+ *     bar were retracted), so the page was taller than the visible area → the
+ *     tab bar fell below the fold. Pinning the root to the *dynamic* viewport
+ *     (`100dvh`) makes the layout always fit the currently-visible viewport.
+ *
+ *  2. Modern Android (15+) Chrome draws web content edge-to-edge *underneath*
+ *     the system navigation bar, and iOS Safari draws under the home indicator.
+ *     `viewport-fit=cover` is required to expose the OS inset via
+ *     `env(safe-area-inset-bottom)`, and we then apply that inset as bottom
+ *     padding on `#root` so the whole layout (incl. the tab bar) stays clear of
+ *     the nav bar. `react-native-safe-area-context` reports `insets.bottom = 0`
+ *     on web, so this CSS padding is what actually creates the gap — the tab
+ *     bar's own `insets.bottom` padding is a no-op here.
  */
 export default function Root({ children }: PropsWithChildren) {
   return (
@@ -38,8 +45,12 @@ export default function Root({ children }: PropsWithChildren) {
 }
 
 // Use the dynamic viewport height where supported so the bottom tab bar is
-// never hidden behind the browser URL bar or the system navigation bar. Falls
-// back to `100%` (the ScrollViewStyleReset default) on older browsers.
+// never hidden behind the browser URL bar, and pad the root by the OS bottom
+// inset so it clears the system navigation bar (Android 15+ edge-to-edge) /
+// home indicator (iOS). `env(safe-area-inset-bottom)` falls back to 0 on
+// browsers that don't draw under the system bars, so there is no regression
+// there. `box-sizing: border-box` keeps the padded root exactly one viewport
+// tall instead of overflowing.
 const viewportFixStyle = `
 @supports (height: 100dvh) {
   html,
@@ -47,5 +58,9 @@ const viewportFixStyle = `
   #root {
     height: 100dvh;
   }
+}
+#root {
+  box-sizing: border-box;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 `;


### PR DESCRIPTION
## Problem

Follow-up to #224. After that fix, the bottom tab bar on https://ai-budget.pl is **still clipped** on a Samsung phone — the labels (Pulpit / Transakcje / Budżet / Analityka / Czat AI) sit behind the system navigation bar.

**Root cause:** this is a modern Android (15+) device, where Chrome now forces **edge-to-edge** rendering — web content is drawn *underneath* the system navigation bar. #224 correctly added `viewport-fit=cover` (required to expose the OS inset on Android 15), but never actually *applied* the inset. `react-native-safe-area-context` returns `insets.bottom = 0` on web, so the tab bar's own safe-area padding is a no-op.

## Fix

Apply the OS inset as CSS padding on `#root` in the web document:

```css
#root {
  box-sizing: border-box;
  padding-bottom: env(safe-area-inset-bottom, 0px);
}
```

`env()` works in CSS (unlike RN style numbers), so this is what actually creates the gap that keeps the whole layout — including the tab bar — clear of the system nav bar (Android) / home indicator (iOS). Falls back to `0` on browsers that don't render under the system bars, so there's no regression.

## Scope / safety

- **Native unaffected:** `+html.tsx` is web-only (Expo Router web export); never included in the native bundle.
- No changes to tab bar layout code, stores, or shared logic.
- Auto-deploys via `web-deploy.yml` on merge to `development`.

## Note

Could not build the web bundle locally (deps not installed in this environment). Change is plain CSS in the standard Expo web document.

https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM

---
_Generated by [Claude Code](https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM)_