### PR TITLE
fix(mobile-web): apply safe-area viewport fix at runtime (SPA ignores +html.tsx)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -31,6 +31,7 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AiUsageBadge } from '@/components/AiUsageBadge';
 import { UpdatePrompt } from '@/components/UpdatePrompt';
 import { useOrientationLock } from '@/hooks/useOrientationLock';
+import { applyWebViewportFix } from '@/utils/webViewportFix';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
@@ -50,6 +51,12 @@ function RootNavigator() {
   const theme = useTheme();
 
   useOrientationLock();
+
+  // Web-only: keep the bottom tab bar clear of the system nav bar / home
+  // indicator (no-op on native). Runs once on mount.
+  useEffect(() => {
+    applyWebViewportFix();
+  }, []);
 
   const [fontsLoaded] = useFonts({
     Montserrat_400Regular,

--- a/apps/mobile/src/utils/webViewportFix.ts
+++ b/apps/mobile/src/utils/webViewportFix.ts
@@ -1,0 +1,7 @@
+// Native (iOS/Android) no-op. The real implementation lives in
+// `webViewportFix.web.ts` and only runs in the browser. Metro resolves the
+// `.web.ts` variant for the web bundle and this file for native, so importing
+// `@/utils/webViewportFix` is safe from shared code.
+export function applyWebViewportFix(): void {
+  // intentionally empty on native
+}

--- a/apps/mobile/src/utils/webViewportFix.web.ts
+++ b/apps/mobile/src/utils/webViewportFix.web.ts
@@ -1,0 +1,50 @@
+// Web-only viewport / safe-area fix.
+//
+// Why this is runtime JS and not `app/+html.tsx`: the app builds with
+// `web.output: "single"` (SPA). `+html.tsx` is honored for *static* rendering
+// but not reliably for single-page output, so styles placed there may never
+// reach the page. This runs from the root layout, which is always in the JS
+// bundle, so it always applies.
+//
+// What it fixes: on modern Android (15+) Chrome draws web content edge-to-edge
+// *underneath* the system navigation bar (and iOS Safari under the home
+// indicator), which clipped the bottom tab bar. We:
+//   1. add `viewport-fit=cover` to the viewport meta — required for the browser
+//      to expose the OS inset via `env(safe-area-inset-bottom)`;
+//   2. pin the root to the dynamic viewport (`100dvh`) and pad it by that inset
+//      so the whole layout (incl. the tab bar) stays clear of the nav bar.
+// On browsers that don't draw under the system bars, the inset resolves to 0 —
+// no regression.
+
+const STYLE_ID = 'web-safe-area-fix';
+
+export function applyWebViewportFix(): void {
+  if (typeof document === 'undefined') return;
+
+  // 1. Ensure the viewport meta opts into edge-to-edge so safe-area insets resolve.
+  let meta = document.querySelector('meta[name="viewport"]') as HTMLMetaElement | null;
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = 'viewport';
+    document.head.appendChild(meta);
+  }
+  const content = meta.getAttribute('content') || 'width=device-width, initial-scale=1';
+  if (!/viewport-fit\s*=\s*cover/.test(content)) {
+    meta.setAttribute('content', `${content}, viewport-fit=cover`);
+  }
+
+  // 2. Inject the height + safe-area padding rules (once).
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+@supports (height: 100dvh) {
+  html, body, #root { height: 100dvh; }
+}
+#root {
+  box-sizing: border-box;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+`;
+  document.head.appendChild(style);
+}


### PR DESCRIPTION
## Why #224 and #225 had no effect

Both prior fixes lived in `app/+html.tsx`. But this app builds with `web.output: "single"` (SPA), and `+html.tsx` is only reliably honored for **static** rendering — for single-page output the styles there never reach the page. That's why three deploys produced an identical result: `viewport-fit=cover`, `100dvh`, and the safe-area padding were never actually applied.

## Fix

Move the fix into **runtime JS that always ships in the bundle**:

- New web-only `applyWebViewportFix()` (`src/utils/webViewportFix.web.ts`; native `.ts` is a no-op via platform resolution), called once from the root layout.
- It (1) adds `viewport-fit=cover` to the `<meta viewport>` (required for the browser to expose the OS inset), and (2) injects `100dvh` + `padding-bottom: env(safe-area-inset-bottom)` on `#root` so the layout — including the bottom tab bar — clears the Android system navigation bar / iOS home indicator.
- Resolves to `0` on browsers that don't draw under the system bars → no regression.

`+html.tsx` is left in place (harmless; would still help a future static build).

## Scope / safety

- **Native unaffected:** `webViewportFix.ts` is a no-op on iOS/Android; only `.web.ts` touches the DOM, guarded by `typeof document`.
- Auto-deploys via `web-deploy.yml` on merge to `development`.

## Note

Still can't build/verify the bundle in this environment (deps not installed; outbound network to docs/site is blocked). If the bottom is *still* clipped after this deploys, it means this device's Chrome reports `env(safe-area-inset-bottom) = 0` even with `viewport-fit=cover`, and the next step is a JS-measured fallback inset.

https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM

---
_Generated by [Claude Code](https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM)_