### PR TITLE
fix(mobile-web): floor bottom inset on Android + opt-in safe-area diagnostics

### DIFF
--- a/apps/mobile/src/utils/webViewportFix.web.ts
+++ b/apps/mobile/src/utils/webViewportFix.web.ts
@@ -2,26 +2,45 @@
 //
 // Why this is runtime JS and not `app/+html.tsx`: the app builds with
 // `web.output: "single"` (SPA). `+html.tsx` is honored for *static* rendering
-// but not reliably for single-page output, so styles placed there may never
-// reach the page. This runs from the root layout, which is always in the JS
-// bundle, so it always applies.
+// but not for single-page output, so styles placed there never reach the page.
+// This runs from the root layout, which is always in the JS bundle.
 //
 // What it fixes: on modern Android (15+) Chrome draws web content edge-to-edge
 // *underneath* the system navigation bar (and iOS Safari under the home
-// indicator), which clipped the bottom tab bar. We:
-//   1. add `viewport-fit=cover` to the viewport meta — required for the browser
-//      to expose the OS inset via `env(safe-area-inset-bottom)`;
-//   2. pin the root to the dynamic viewport (`100dvh`) and pad it by that inset
-//      so the whole layout (incl. the tab bar) stays clear of the nav bar.
-// On browsers that don't draw under the system bars, the inset resolves to 0 —
-// no regression.
+// indicator), which clipped the bottom tab bar. We add `viewport-fit=cover`,
+// pin the root to the dynamic viewport (`100dvh`), and pad the root by the OS
+// bottom inset so the tab bar clears the nav bar.
+//
+// The spec way to read the inset is `env(safe-area-inset-bottom)`, but some
+// Android Chrome builds report it as 0 even with `viewport-fit=cover`. So on
+// touch Android we floor the padding at a sensible 3-button nav-bar height via
+// `max(env(...), FALLBACK)`. Where `env()` resolves correctly (iOS, newer
+// Chrome) the larger real value wins, so there is no double padding.
 
 const STYLE_ID = 'web-safe-area-fix';
+const ANDROID_NAV_FALLBACK_PX = 48;
+
+function getRootEl(): HTMLElement | null {
+  return (document.getElementById('root') as HTMLElement | null) ?? document.body ?? null;
+}
+
+// Read the actual resolved value of an `env(safe-area-inset-*)` in pixels by
+// measuring a hidden probe element (works even when CSS `env()` is supported
+// but reports 0).
+function readEnvInsetPx(side: 'top' | 'bottom'): number {
+  if (!document.body) return 0;
+  const probe = document.createElement('div');
+  probe.style.cssText = `position:fixed;left:0;${side}:0;width:0;height:env(safe-area-inset-${side},0px);visibility:hidden;pointer-events:none;`;
+  document.body.appendChild(probe);
+  const h = probe.getBoundingClientRect().height;
+  probe.remove();
+  return Math.round(h);
+}
 
 export function applyWebViewportFix(): void {
   if (typeof document === 'undefined') return;
 
-  // 1. Ensure the viewport meta opts into edge-to-edge so safe-area insets resolve.
+  // 1. Opt into edge-to-edge so the browser exposes the OS safe-area insets.
   let meta = document.querySelector('meta[name="viewport"]') as HTMLMetaElement | null;
   if (!meta) {
     meta = document.createElement('meta');
@@ -33,18 +52,49 @@ export function applyWebViewportFix(): void {
     meta.setAttribute('content', `${content}, viewport-fit=cover`);
   }
 
-  // 2. Inject the height + safe-area padding rules (once).
-  if (document.getElementById(STYLE_ID)) return;
-  const style = document.createElement('style');
-  style.id = STYLE_ID;
-  style.textContent = `
-@supports (height: 100dvh) {
-  html, body, #root { height: 100dvh; }
+  // 2. Pin the root chain to the dynamic viewport height (once).
+  if (!document.getElementById(STYLE_ID)) {
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `@supports (height: 100dvh){html,body,#root{height:100dvh;}}`;
+    document.head.appendChild(style);
+  }
+
+  // 3. Pad the actual root element by the bottom inset (floored on Android).
+  const isAndroid = /Android/i.test(navigator.userAgent || '');
+  const coarse =
+    typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches;
+  const fallback = isAndroid && coarse ? `${ANDROID_NAV_FALLBACK_PX}px` : '0px';
+
+  const rootEl = getRootEl();
+  if (rootEl) {
+    rootEl.style.boxSizing = 'border-box';
+    rootEl.style.paddingBottom = `max(env(safe-area-inset-bottom, 0px), ${fallback})`;
+  }
+
+  // 4. Optional on-device diagnostics: open the site with `?sadebug=1` to see a
+  //    small readout (not shown to normal visitors). Helps tune the inset.
+  if (/[?&]sadebug=1\b/.test(window.location.search)) {
+    showDebugOverlay(isAndroid, coarse, fallback);
+  }
 }
-#root {
-  box-sizing: border-box;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-}
-`;
-  document.head.appendChild(style);
+
+function showDebugOverlay(isAndroid: boolean, coarse: boolean, fallback: string): void {
+  if (document.getElementById('sa-debug')) return;
+  const envBottom = readEnvInsetPx('bottom');
+  const envTop = readEnvInsetPx('top');
+  const rootEl = document.getElementById('root') as HTMLElement | null;
+  const pb = rootEl ? getComputedStyle(rootEl).paddingBottom : 'n/a';
+  const box = document.createElement('div');
+  box.id = 'sa-debug';
+  box.style.cssText =
+    'position:fixed;top:0;left:0;right:0;z-index:99999;background:rgba(0,0,0,0.85);color:#0f0;font:11px/1.4 monospace;padding:6px 8px;white-space:pre-wrap;pointer-events:none;';
+  box.textContent = [
+    `env.bottom=${envBottom}px env.top=${envTop}px`,
+    `android=${isAndroid} coarse=${coarse} fallback=${fallback}`,
+    `root#=${!!rootEl} root.pb=${pb}`,
+    `innerH=${window.innerHeight} clientH=${document.documentElement.clientHeight} screenH=${window.screen?.height} dpr=${window.devicePixelRatio}`,
+    `vv.h=${window.visualViewport ? Math.round(window.visualViewport.height) : 'n/a'}`,
+  ].join('\n');
+  document.body.appendChild(box);
 }


### PR DESCRIPTION
## Context

After #226's runtime fix actually applied, the bottom tab bar is **still** clipped. That tells us this device's Chrome reports `env(safe-area-inset-bottom) = 0` even with `viewport-fit=cover`. The web platform exposes no other API for the system navigation bar height (visual/layout viewport both extend *under* the nav bar in edge-to-edge mode), so `env()` is the only OS-inset source — and here it's empty.

## Fix

- **Floor the inset on touch Android:** `padding-bottom: max(env(safe-area-inset-bottom, 0px), 48px)` so the tab bar clears a standard 3-button nav bar even when `env()` is 0. Where `env()` does resolve (iOS, newer Chrome) the larger real value wins → no double padding, no dead space.
- Apply padding to the **actually-resolved** root element (`getElementById('root') ?? body`) rather than trusting a CSS `#root` selector.
- **Opt-in on-device diagnostics:** open the site with `?sadebug=1` to show a tiny readout (resolved env insets, viewport sizes, applied padding). Hidden from normal visitors. Lets me tune the inset from real device numbers if 48px isn't pixel-perfect.

## Scope / safety

- **Native unaffected:** web-only module; native `.ts` is a no-op.
- Diagnostic overlay only renders with the `?sadebug=1` query param.
- Auto-deploys via `web-deploy.yml` on merge to `development`.

## How to verify after deploy

1. Normal: reload in incognito — the tab bar should clear the nav bar.
2. If still off: open `https://ai-budget.pl/?sadebug=1`, screenshot the green readout at the top, and I'll tune the exact value.

https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM

---
_Generated by [Claude Code](https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM)_