### PR TITLE
fix(mobile-web): fix voice/receipt base64 read on web (this.validatePath crash)

### DIFF
--- a/apps/mobile/app/expense/components/ReceiptSection.tsx
+++ b/apps/mobile/app/expense/components/ReceiptSection.tsx
@@ -15,6 +15,7 @@ import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
 import * as DocumentPicker from 'expo-document-picker';
 import { File, Paths } from 'expo-file-system/next';
+import { uriToBase64 } from '@/utils/fileBase64';
 import * as Sharing from 'expo-sharing';
 import * as MediaLibrary from 'expo-media-library';
 import { useExpenseStore } from '@/stores/expenseStore';
@@ -84,8 +85,7 @@ export function ReceiptSection({ expenseId }: ReceiptSectionProps) {
       [{ resize: { width: 800 } }],
       { compress: 0.6, format: ImageManipulator.SaveFormat.JPEG },
     );
-    const compressedFile = new File(compressed.uri);
-    return await compressedFile.base64();
+    return await uriToBase64(compressed.uri);
   };
 
   const handleAttachFromCamera = async () => {
@@ -118,8 +118,7 @@ export function ReceiptSection({ expenseId }: ReceiptSectionProps) {
     });
     if (result.canceled) return;
     const asset = result.assets[0];
-    const file = new File(asset.uri);
-    const base64 = await file.base64();
+    const base64 = await uriToBase64(asset.uri);
     await saveReceiptImage(expenseId, base64, 'application/pdf');
     setReceiptImageBase64(base64);
     setReceiptMimeType('application/pdf');

--- a/apps/mobile/app/expense/receipt.tsx
+++ b/apps/mobile/app/expense/receipt.tsx
@@ -14,7 +14,7 @@ import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import * as ImageManipulator from 'expo-image-manipulator';
-import { File } from 'expo-file-system/next';
+import { uriToBase64 } from '@/utils/fileBase64';
 import { useReceiptScanner } from '@/features/receipt/useReceiptScanner';
 import { useExpenseStore } from '@/stores/expenseStore';
 import { useAuthStore } from '@/stores/authStore';
@@ -34,8 +34,7 @@ async function compressAndEncodeImage(uri: string): Promise<string> {
     [{ resize: { width: 800 } }],
     { compress: 0.6, format: ImageManipulator.SaveFormat.JPEG },
   );
-  const file = new File(result.uri);
-  return await file.base64();
+  return await uriToBase64(result.uri);
 }
 
 export default function ReceiptExpenseScreen() {

--- a/apps/mobile/app/income/voice.tsx
+++ b/apps/mobile/app/income/voice.tsx
@@ -14,7 +14,7 @@ import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { Audio } from 'expo-av';
-import { File } from 'expo-file-system/next';
+import { uriToBase64 } from '@/utils/fileBase64';
 import { useIncomeStore } from '@/stores/incomeStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useCategoryStore } from '@/stores/categoryStore';
@@ -114,8 +114,7 @@ export default function VoiceIncomeScreen() {
       setRecordingRef(null);
       if (!uri) throw new Error('No recording URI');
 
-      const file = new File(uri);
-      const base64Audio = await file.base64();
+      const base64Audio = await uriToBase64(uri);
       const transcriptionResult = await api.transcribeAudio(base64Audio);
       setTranscription(transcriptionResult.text);
 

--- a/apps/mobile/src/features/receipt/useReceiptScanner.ts
+++ b/apps/mobile/src/features/receipt/useReceiptScanner.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import * as ImagePicker from 'expo-image-picker';
-import { File } from 'expo-file-system/next';
+import { uriToBase64 } from '@/utils/fileBase64';
 import { api } from '@/services/api';
 import i18n from '@/i18n';
 
@@ -136,8 +136,7 @@ export function useReceiptScanner() {
         scannedReceipt: null,
       }));
 
-      const file = new File(asset.uri);
-      const base64 = await file.base64();
+      const base64 = await uriToBase64(asset.uri);
 
       const scannedReceipt = await api.scanReceipt(base64, userPrompt || undefined, 'application/pdf');
 
@@ -174,8 +173,7 @@ export function useReceiptScanner() {
 
     try {
       // Read image as base64
-      const file = new File(imageUri);
-      const base64 = await file.base64();
+      const base64 = await uriToBase64(imageUri);
 
       // Send to API for OCR
       const scannedReceipt = await api.scanReceipt(base64, userPrompt || undefined);

--- a/apps/mobile/src/features/voice/useVoiceInput.ts
+++ b/apps/mobile/src/features/voice/useVoiceInput.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { Audio } from 'expo-av';
-import { File } from 'expo-file-system/next';
+import { uriToBase64 } from '@/utils/fileBase64';
 import { api } from '@/services/api';
 import i18n from '@/i18n';
 
@@ -96,8 +96,7 @@ export function useVoiceInput() {
       }
 
       // Read the recording file as base64 string
-      const file = new File(uri);
-      const base64Audio = await file.base64();
+      const base64Audio = await uriToBase64(uri);
 
       // Transcribe audio
       const transcriptionResult = await api.transcribeAudio(base64Audio);

--- a/apps/mobile/src/utils/fileBase64.ts
+++ b/apps/mobile/src/utils/fileBase64.ts
@@ -1,0 +1,32 @@
+import { Platform } from 'react-native';
+import { File } from 'expo-file-system/next';
+
+// Read a file URI as a base64 string (no data-URL prefix), cross-platform.
+//
+// On native we use expo-file-system's `File.base64()`. On web that class is not
+// implemented (its internal `validatePath` is missing → "this.validatePath is
+// not a function"), and recorded/picked URIs are `blob:`/`data:` URLs anyway,
+// so we fetch the URI and decode it with FileReader.
+export async function uriToBase64(uri: string): Promise<string> {
+  if (Platform.OS === 'web') {
+    const res = await fetch(uri);
+    const blob = await res.blob();
+    return blobToBase64(blob);
+  }
+  const file = new File(uri);
+  return file.base64();
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      // `result` is a data URL ("data:<mime>;base64,XXXX") — strip the prefix.
+      const comma = result.indexOf(',');
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read blob'));
+    reader.readAsDataURL(blob);
+  });
+}


### PR DESCRIPTION
## Problem

On web, asking the AI by voice (and likely receipt OCR) fails with **`this.validatePath is not a function`** after "Przetwarzanie głosu…".

**Cause:** the voice/receipt flows read the recorded/picked URI with `new File(uri).base64()` from `expo-file-system/next`. That `File` class isn't implemented for web (its internal `validatePath` is missing), and on web these URIs are `blob:`/`data:` URLs that expo-file-system can't read anyway.

## Fix

Add a cross-platform `uriToBase64()` helper (`src/utils/fileBase64.ts`):
- **Native:** `expo-file-system` `File.base64()` (unchanged behavior).
- **Web:** `fetch(uri)` → `blob` → `FileReader.readAsDataURL` → strip the data-URL prefix.

Route every URI→base64 read through it:
- `useVoiceInput` (chat + expense voice) ← the reported crash
- `income/voice`
- `useReceiptScanner` (image + PDF OCR)
- `expense/receipt`, `expense/components/ReceiptSection`

Cache-file *writes* that genuinely need `expo-file-system` `Paths` (share/save receipt) are left as-is.

## Scope / safety

- Native behavior unchanged (same code path via `Platform.OS`).
- Unblocks voice chat and receipt scanning on the web build.
- Auto-deploys via `web-deploy.yml` on merge.

Separately: the bottom tab-bar label clipping from earlier in this thread is confirmed fixed by #228.

https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM

---
_Generated by [Claude Code](https://claude.ai/code/session_012N3iwsKnzRhEgesNMMspfM)_