### PR TITLE
fix(mobile): navigate back after capture-save on web

### DIFF
--- a/apps/mobile/app/expense/receipt.tsx
+++ b/apps/mobile/app/expense/receipt.tsx
@@ -146,7 +146,7 @@ export default function ReceiptExpenseScreen() {
       });
 
       showAlert(t('common.success'), t('receipt.success'), [
-        { text: t('receipt.scanAnother'), onPress: handleReset },
+        { text: t('receipt.scanAnother'), style: 'cancel', onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {

--- a/apps/mobile/app/expense/voice.tsx
+++ b/apps/mobile/app/expense/voice.tsx
@@ -130,7 +130,7 @@ export default function VoiceExpenseScreen() {
       });
 
       showAlert(t('common.success'), t('voice.success'), [
-        { text: t('voice.addAnother'), onPress: handleReset },
+        { text: t('voice.addAnother'), style: 'cancel', onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {

--- a/apps/mobile/app/income/receipt.tsx
+++ b/apps/mobile/app/income/receipt.tsx
@@ -87,7 +87,7 @@ export default function ReceiptIncomeScreen() {
       });
 
       showAlert(t('common.success'), t('incomeReceipt.success'), [
-        { text: t('incomeReceipt.scanAnother'), onPress: handleReset },
+        { text: t('incomeReceipt.scanAnother'), style: 'cancel', onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {

--- a/apps/mobile/app/income/voice.tsx
+++ b/apps/mobile/app/income/voice.tsx
@@ -167,7 +167,7 @@ export default function VoiceIncomeScreen() {
         isDebtRepayment: false,
       });
       showAlert(t('common.success'), t('incomeVoice.success'), [
-        { text: t('incomeVoice.addAnother'), onPress: handleReset },
+        { text: t('incomeVoice.addAnother'), style: 'cancel', onPress: handleReset },
         { text: t('common.done'), onPress: () => router.back() },
       ]);
     } catch {


### PR DESCRIPTION
## Problem

On the web build, adding an expense via receipt scan worked, but after saving the user stayed on the same screen instead of navigating back.

## Root cause

`react-native-web` stubs out native `Alert`, so the project's `showAlert` wrapper (`apps/mobile/src/utils/alert.ts`) maps a two-button alert onto the browser's `window.confirm`:

- **OK** → first button whose `style !== 'cancel'`
- **Cancel** → button whose `style === 'cancel'`

The success alert in the capture screens had no `cancel` style on either button:

```ts
showAlert(t('common.success'), t('receipt.success'), [
  { text: t('receipt.scanAnother'), onPress: handleReset },     // no style
  { text: t('common.done'), onPress: () => router.back() },     // no style
]);
```

So on web, **OK** resolved to `scanAnother` (`handleReset` — stays on screen) and **Cancel** resolved to nothing — `router.back()` was never reached. Native was unaffected (both buttons render normally).

## Fix

Mark the "scan/add another" button as `style: 'cancel'` so on web **OK → Done** (`router.back()`) and **Cancel → scan another** (`handleReset`). Applied to all four capture screens:

- `apps/mobile/app/expense/receipt.tsx`
- `apps/mobile/app/expense/voice.tsx`
- `apps/mobile/app/income/receipt.tsx`
- `apps/mobile/app/income/voice.tsx`

Native behavior is unchanged aside from the cancel button's standard styling/position.

https://claude.ai/code/session_014mo7es4EWHW5RSeSiRPhAj

---
_Generated by [Claude Code](https://claude.ai/code/session_014mo7es4EWHW5RSeSiRPhAj)_