### PR TITLE
hotfix(api): fix prod crash-loop from shared-utils barrel runtime import

### DIFF
--- a/apps/api/src/modules/insights/safe-to-spend.service.ts
+++ b/apps/api/src/modules/insights/safe-to-spend.service.ts
@@ -3,7 +3,7 @@ import { PrismaService } from '../../database/prisma.service';
 import { WalletService } from '../wallet/wallet.service';
 import { ExchangeRateService } from '../currency-exchange/exchange-rate.service';
 import { CacheService } from '../../common/cache/cache.service';
-import { computeSafeToSpend } from '@budget/shared-utils';
+import { computeSafeToSpend } from './safe-to-spend.util';
 import type { SafeToSpendResponse, AffordabilityVerdict } from '@budget/shared-types';
 
 // How far back we look when inferring monthly income (90 days)

--- a/apps/api/src/modules/insights/safe-to-spend.util.ts
+++ b/apps/api/src/modules/insights/safe-to-spend.util.ts
@@ -1,0 +1,69 @@
+/**
+ * API-local copy of the pure safe-to-spend formula.
+ *
+ * The SAME function is exported from `@budget/shared-utils` (formatting) for the
+ * mobile offline fallback. The API must NOT import it from the `@budget/shared-utils`
+ * package root at runtime: the prod ESM runtime resolves the package barrel
+ * (`shared-utils/src/index.ts` → `export * from './validation'`) and throws
+ * `ERR_UNSUPPORTED_DIR_IMPORT` on the directory re-export, crash-looping the API.
+ * This mirrors the `budget-period.util.ts` precedent (ABA-171).
+ *
+ * Keep this copy and the `shared-utils` copy in sync — do NOT add a third copy.
+ */
+
+export interface SafeToSpendInputs {
+  /** Σ wallet current balances, already converted to base currency */
+  walletBalance: number;
+  /** Expected income before horizon, 0 when not inferred */
+  expectedIncome: number;
+  /** Σ upcoming active subscriptions due ≤ horizon, converted */
+  upcomingSubscriptions: number;
+  /** Σ upcoming recurring expenses due ≤ horizon, converted */
+  upcomingRecurring: number;
+  /** Σ on-track goal contributions due before horizon, converted */
+  goalContributions: number;
+  /** Safety buffer (default 0 for v1) */
+  buffer: number;
+  /** Days remaining until horizon (inclusive, min 1) */
+  daysRemaining: number;
+}
+
+export interface SafeToSpendResult {
+  projectedObligations: number;
+  projectedAvailable: number;
+  /** max(0, (projectedAvailable - buffer) / daysRemaining) */
+  safeToSpendToday: number;
+}
+
+/**
+ * Pure deterministic safe-to-spend formula.
+ * All monetary inputs MUST already be converted to the same base currency.
+ */
+export function computeSafeToSpend(inputs: SafeToSpendInputs): SafeToSpendResult {
+  const {
+    walletBalance,
+    expectedIncome,
+    upcomingSubscriptions,
+    upcomingRecurring,
+    goalContributions,
+    buffer,
+    daysRemaining,
+  } = inputs;
+
+  const projectedObligations =
+    Math.max(0, upcomingSubscriptions) +
+    Math.max(0, upcomingRecurring) +
+    Math.max(0, goalContributions);
+
+  const projectedAvailable =
+    walletBalance + Math.max(0, expectedIncome) - projectedObligations;
+
+  const safeDays = Math.max(1, daysRemaining);
+  const safeToSpendToday = Math.max(0, (projectedAvailable - buffer) / safeDays);
+
+  return {
+    projectedObligations: Math.round(projectedObligations * 100) / 100,
+    projectedAvailable: Math.round(projectedAvailable * 100) / 100,
+    safeToSpendToday: Math.round(safeToSpendToday * 100) / 100,
+  };
+}


### PR DESCRIPTION
## Problem
The ABA-293 deploy crash-looped `budget-api-prod` (health endpoint returned 502, deploy verify failed). Runtime error:

```
ERR_UNSUPPORTED_DIR_IMPORT: Directory import '/app/packages/shared-utils/src/validation'
is not supported resolving ES modules imported from .../shared-utils/src/index.ts
```

`safe-to-spend.service.ts` imported `computeSafeToSpend` from the `@budget/shared-utils` package root. That pulls the package barrel (`src/index.ts` → `export * from './validation'`), and the production ESM runtime cannot resolve the directory re-export, so the API process exited on boot and Docker restarted it in a loop.

## Fix
Use an API-local copy of the pure formula (`safe-to-spend.util.ts`) and import it relatively — exactly the established `budget-period.util.ts` precedent (ABA-171), where the API keeps its own copy and `shared-utils` exports the same function for the mobile/admin bundles. No behavior change; the formula is byte-identical and documented to stay in sync.

- New `apps/api/src/modules/insights/safe-to-spend.util.ts` (formula + interfaces, copied).
- `safe-to-spend.service.ts` imports from `./safe-to-spend.util` instead of `@budget/shared-utils`.

Verified: no remaining runtime `@budget/shared-utils` import in `apps/api/src`; api typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbRQ22TGCw6NdJwx4xEgsG)_