### PR TITLE
fix(mobile): mobile-quality typecheck errors in notification capture

### DIFF
--- a/apps/mobile/app/settings/auto-capture.tsx
+++ b/apps/mobile/app/settings/auto-capture.tsx
@@ -281,7 +281,7 @@ const createStyles = (theme: Theme) => ({
   },
   sectionTitle: {
     ...theme.textStyles.h3,
-    color: theme.colors.text,
+    color: theme.colors.textPrimary,
     marginBottom: theme.spacing[2],
   },
   sectionSubtitle: {
@@ -313,7 +313,7 @@ const createStyles = (theme: Theme) => ({
   permissionGrantedText: {
     ...theme.textStyles.body,
     color: theme.colors.success,
-    fontFamily: theme.fonts.semibold,
+    fontFamily: theme.fonts.semiBold,
   },
   permissionHint: {
     ...theme.textStyles.caption,
@@ -332,7 +332,7 @@ const createStyles = (theme: Theme) => ({
   buttonText: {
     ...theme.textStyles.body,
     color: theme.colors.textInverse,
-    fontFamily: theme.fonts.semibold,
+    fontFamily: theme.fonts.semiBold,
   },
   toggleRow: {
     flexDirection: 'row' as const,
@@ -341,7 +341,7 @@ const createStyles = (theme: Theme) => ({
   },
   toggleLabel: {
     ...theme.textStyles.body,
-    color: theme.colors.text,
+    color: theme.colors.textPrimary,
     flex: 1,
   },
   toggleHint: {
@@ -353,7 +353,7 @@ const createStyles = (theme: Theme) => ({
     ...theme.textStyles.caption,
     color: theme.colors.textTertiary,
     textTransform: 'uppercase' as const,
-    fontFamily: theme.fonts.semibold,
+    fontFamily: theme.fonts.semiBold,
     marginBottom: theme.spacing[2],
   },
   bankRow: {
@@ -368,7 +368,7 @@ const createStyles = (theme: Theme) => ({
   },
   bankLabel: {
     ...theme.textStyles.body,
-    color: theme.colors.text,
+    color: theme.colors.textPrimary,
     flex: 1,
   },
   capturedRow: {
@@ -382,7 +382,7 @@ const createStyles = (theme: Theme) => ({
   },
   capturedMerchant: {
     ...theme.textStyles.body,
-    color: theme.colors.text,
+    color: theme.colors.textPrimary,
     fontFamily: theme.fonts.medium,
   },
   capturedMeta: {

--- a/apps/mobile/src/services/notificationCapture/index.ts
+++ b/apps/mobile/src/services/notificationCapture/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Base module resolution for `@/services/notificationCapture`.
+ *
+ * Metro picks the platform file at bundle time: `index.android.ts` (real native
+ * module), `index.ios.ts` / `index.web.ts` (no-op stubs). TypeScript (`tsc`) does
+ * NOT understand platform extensions, so it needs this base `index.ts` to resolve
+ * the module — mirroring the `secureStorage.ts` base + `.native.ts`/`.web.ts`
+ * override convention. The base re-exports the no-op stub: identical type surface
+ * to every platform variant, and a safe fallback on any non-Android/iOS/web target.
+ */
+export * from './index.ios';

--- a/apps/mobile/src/services/notificationParser/generic.ts
+++ b/apps/mobile/src/services/notificationParser/generic.ts
@@ -282,7 +282,7 @@ export function parseGeneric(title: string, text: string): GenericParseResult | 
 
   // --- Merchant (best-effort, may be null) ---
   const rawMerchant = extractMerchantRaw(fullText);
-  const merchant = normalizeMerchant(rawMerchant) ?? null;
+  const merchant = normalizeMerchant(rawMerchant ?? undefined) ?? null;
 
   return { amount, currencyCode: currencyResult.code, merchant };
 }


### PR DESCRIPTION
## Problem
The ABA-295 merge turned **Mobile Quality Checks** red (`@budget/mobile#typecheck` exited 2). The errors were latent from ABA-294 too — local `tsc` exits early on a missing `expo/tsconfig.base` in this environment, so it never reached the real typecheck and reported a false "clean". CI (with expo installed) surfaced them.

## Fixes (the complete CI error set, one tsc pass)
- **`@/services/notificationCapture` unresolved (3×)** + the cascaded implicit-`any` on `enabled` in `_layout.tsx`: added a base `src/services/notificationCapture/index.ts` that re-exports the no-op stub. `tsc` doesn't understand platform extensions (`index.android/ios/web.ts`), so it needs a base — mirrors the `secureStorage.ts` + `.native/.web` convention. Metro still picks the platform file. Verified android/ios stub export parity (identical surface), so consumer imports type-check.
- **`auto-capture.tsx`**: `theme.colors.text` → `textPrimary` (4×), `theme.fonts.semibold` → `semiBold` (3×) — confirmed against the theme types.
- **`generic.ts`**: pass `rawMerchant ?? undefined` to `normalizeMerchant(string | undefined)` (was `string | null`).

## Verification note
Mobile typecheck is **not runnable locally** here (`expo` isn't in node_modules → `tsc` aborts on the missing base config), so this is verified via the **Mobile Quality Checks** run on this PR rather than locally. Holding merge until that check is green.

Refs ABA-294, ABA-295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbRQ22TGCw6NdJwx4xEgsG)_