### PR TITLE
fix(android): EAS build Kotlin compile error in NotificationCaptureModule

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/budget/assistant/notifications/NotificationCaptureModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/budget/assistant/notifications/NotificationCaptureModule.kt
@@ -116,8 +116,4 @@ class NotificationCaptureModule(private val reactContext: ReactApplicationContex
             promise.resolve(false)
         }
     }
-
-    // Required for DeviceEventEmitter subscriptions on new React Native versions
-    override fun addListener(eventName: String) { /* no-op */ }
-    override fun removeListeners(count: Double) { /* no-op */ }
 }


### PR DESCRIPTION
## Problem
The **Mobile Build & Publish** EAS build failed at `:app:compileReleaseKotlin`:
```
e: NotificationCaptureModule.kt:121: 'addListener' overrides nothing.
e: NotificationCaptureModule.kt:122: 'removeListeners' overrides nothing.
```
`ReactContextBaseJavaModule` (Old-Arch, RN 0.81) declares no `addListener`/`removeListeners` to override, so the `override` modifier failed to compile. The **Mobile Quality Checks** workflow only runs JS lint/typecheck — it never compiles Kotlin, so this only surfaces in the EAS Gradle build (and was latent since ABA-294).

## Fix
Removed both methods entirely. They're only needed when the JS side uses `new NativeEventEmitter(NativeModules.X)`; ours subscribes via the **global `DeviceEventEmitter`** (`DeviceEventEmitter.addListener('onBankNotification', …)`), which doesn't call them. The native emit still uses `RCTDeviceEventEmitter`. Remaining `override`s (`onNotificationPosted`, `getName`, `createNativeModules`, …) are all legitimate base-class methods.

## Verification note
The Android Kotlin compile can only be verified by the EAS build (no Android toolchain in CI sandbox). After merge, re-run **Mobile Build & Publish** to confirm `compileReleaseKotlin` passes.

Refs ABA-294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbRQ22TGCw6NdJwx4xEgsG)_