### PR TITLE
fix(mobile): de-dupe safe-to-spend on home + fix breakdown row layout

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -363,34 +363,9 @@ export default function DashboardScreen() {
           const mapped = [...new Set(widgetOrder)].map((key) => {
           switch (key) {
             case 'safeToSpend':
-              return widgetVisibility.safeToSpend && hasSafeToSpend && safeToSpendData ? (
-                <TouchableOpacity
-                  key="safeToSpend"
-                  style={styles.card}
-                  activeOpacity={0.7}
-                  onPress={() => setSafeToSpendSheetVisible(true)}
-                >
-                  <View style={styles.chevronHint}>
-                    <Ionicons name="information-circle-outline" size={16} color={theme.colors.textTertiary} />
-                  </View>
-                  <View style={styles.cardHeader}>
-                    <Text style={styles.cardTitle}>{t('safeToSpend.title')}</Text>
-                  </View>
-                  <Text style={styles.safeToSpendAmount}>
-                    {formatCurrency(safeToSpendData.safeToSpendToday, safeToSpendData.baseCurrency)}
-                  </Text>
-                  <Text style={styles.safeToSpendSubtitle}>
-                    {t('safeToSpend.subtitle')}
-                    {safeToSpendData.safeToSpendToday === 0 ? ` · ${t('safeToSpend.today')}: 0` : ''}
-                  </Text>
-                  {safeToSpendData.fxApproximate && (
-                    <Text style={styles.safeToSpendNote}>{t('safeToSpend.approxRate')}</Text>
-                  )}
-                  {!safeToSpendData.incomeInferred && (
-                    <Text style={styles.safeToSpendNote}>{t('safeToSpend.noIncomeAssumed')}</Text>
-                  )}
-                </TouchableOpacity>
-              ) : null;
+              // Shown as the home hero number (tap → breakdown sheet). No duplicate
+              // dashboard card — the hero is the single in-app surface for this value.
+              return null;
 
             case 'financialHealth':
               return widgetVisibility.financialHealth ? <FinancialHealthWidget key="financialHealth" /> : null;
@@ -1068,28 +1043,6 @@ const createStyles = (theme: Theme) => ({
     fontWeight: '900' as const,
   },
 
-  // Safe-to-spend widget card
-  safeToSpendAmount: {
-    fontSize: 32,
-    fontFamily: theme.fonts.bold,
-    color: theme.colors.textPrimary,
-    fontWeight: '900' as const,
-    textAlign: 'center' as const,
-    marginBottom: theme.spacing[1],
-  },
-  safeToSpendSubtitle: {
-    ...theme.textStyles.bodySm,
-    color: theme.colors.textSecondary,
-    textAlign: 'center' as const,
-  },
-  safeToSpendNote: {
-    ...theme.textStyles.caption,
-    color: theme.colors.textTertiary,
-    textAlign: 'center' as const,
-    marginTop: theme.spacing[1],
-    fontStyle: 'italic' as const,
-  },
-
   // Safe-to-spend bottom-sheet
   stsBackdrop: {
     flex: 1,
@@ -1122,6 +1075,7 @@ const createStyles = (theme: Theme) => ({
     flexDirection: 'row' as const,
     justifyContent: 'space-between' as const,
     alignItems: 'center' as const,
+    gap: theme.spacing[3],
     paddingVertical: theme.spacing[2],
     borderBottomWidth: 0.5,
     borderBottomColor: theme.colors.border,
@@ -1129,10 +1083,13 @@ const createStyles = (theme: Theme) => ({
   stsRowLabel: {
     ...theme.textStyles.bodySm,
     color: theme.colors.textSecondary,
+    flex: 1,
   },
   stsRowValue: {
     ...theme.textStyles.bodySmMedium,
     color: theme.colors.textPrimary,
+    flexShrink: 0,
+    textAlign: 'right' as const,
   },
   stsDivider: {
     height: 1,
@@ -1143,17 +1100,21 @@ const createStyles = (theme: Theme) => ({
     flexDirection: 'row' as const,
     justifyContent: 'space-between' as const,
     alignItems: 'center' as const,
+    gap: theme.spacing[3],
     marginTop: theme.spacing[2],
   },
   stsTotalLabel: {
     ...theme.textStyles.bodyMedium,
     color: theme.colors.textPrimary,
     fontWeight: '600' as const,
+    flex: 1,
   },
   stsTotalValue: {
     ...theme.textStyles.bodyLargeSemiBold,
     color: theme.colors.primary,
     fontWeight: '900' as const,
+    flexShrink: 0,
+    textAlign: 'right' as const,
   },
   stsNote: {
     ...theme.textStyles.caption,


### PR DESCRIPTION
Two UI bugs reported from a device screenshot (ABA-293).

## 1. Duplicate safe-to-spend on the home screen
The value rendered **twice**: as the hero number at the top *and* as a dashboard card below the quick actions. Removed the card — the hero (tap → breakdown sheet) is the single in-app surface. The Android launcher home-screen widget is a separate surface and is unaffected. Dropped the now-unused card styles.

## 2. Breakdown sheet — total row glued
In "Как это рассчитывается", the total row label ("Безопасно потратить сегодня") and the amount touched with no gap (`сегодня92 770,54 zł`) because the row used `space-between` but the children had no `flex`/`gap`, so a long label left no room. Added `gap` + `flex:1` on labels and `flexShrink:0` + `textAlign:right` on values (total row and line rows).

## Verification note
Mobile typecheck/lint isn't runnable locally here (`expo` missing → `tsc` aborts on the base config). Verified via **Mobile Quality Checks** on this PR; holding merge until green.

Refs ABA-293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbRQ22TGCw6NdJwx4xEgsG)_