### PR TITLE
fix(mobile): auto-capture toggle stays off after granting notification access

### DIFF
--- a/apps/mobile/app/settings/auto-capture.tsx
+++ b/apps/mobile/app/settings/auto-capture.tsx
@@ -12,7 +12,7 @@
  *
  * canEdit-gated — viewers see the list but cannot toggle the feature.
  */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -51,6 +51,11 @@ export default function AutoCaptureScreen() {
   const [captureEnabled, setCaptureEnabled] = useState(false);
   const [checkingPermission, setCheckingPermission] = useState(true);
 
+  // The user tapped "enable" before granting the OS permission, so we opened the
+  // system settings screen and bailed. When they return with permission granted,
+  // finish turning the feature on automatically instead of making them tap again.
+  const pendingEnable = useRef(false);
+
   // Expenses captured via notification (for the review list)
   const expenses = useExpenseStore((s) => s.expenses);
   const capturedExpenses = expenses
@@ -60,9 +65,19 @@ export default function AutoCaptureScreen() {
   const checkPermission = useCallback(async () => {
     setCheckingPermission(true);
     try {
-      const [granted, enabled] = await Promise.all([isPermissionGranted(), isEnabled()]);
+      const granted = await isPermissionGranted();
       setPermissionGranted(granted);
-      setCaptureEnabled(granted && enabled);
+      if (granted && pendingEnable.current) {
+        // Returned from the OS settings screen with permission now granted and a
+        // pending intent to enable — complete it (write the flag + start capture).
+        pendingEnable.current = false;
+        await setEnabled(true);
+        subscribeToCapture();
+        setCaptureEnabled(true);
+      } else {
+        const enabled = await isEnabled();
+        setCaptureEnabled(granted && enabled);
+      }
     } catch {
       setPermissionGranted(false);
       setCaptureEnabled(false);
@@ -85,7 +100,8 @@ export default function AutoCaptureScreen() {
   const handleToggle = async (value: boolean) => {
     if (!canEdit) return;
     if (value && !permissionGranted) {
-      // Redirect to OS settings first
+      // Redirect to OS settings first; remember the intent so we auto-enable on return.
+      pendingEnable.current = true;
       await openPermissionSettings();
       return;
     }
@@ -105,6 +121,8 @@ export default function AutoCaptureScreen() {
   };
 
   const handleGrantPermission = async () => {
+    // Granting permission implies intent to use the feature — auto-enable on return.
+    pendingEnable.current = true;
     await openPermissionSettings();
     // Permission check happens on focus return via useFocusEffect
   };


### PR DESCRIPTION
## Problem (reported from device)
On the Auto-capture screen, tapping the toggle while the OS "notification access" permission isn't yet granted opens the system settings screen and returns **without** writing the enabled flag. On focus-return the permission reads as granted but `isEnabled()` is still `false`, so the toggle shows **off** — the user has to tap it a second time to actually enable the feature. The user reported "granted access, but in our UI auto-capture still shows off."

## Fix
Remember the enable intent (`pendingEnable` ref) when redirecting to OS settings, and on focus-return complete the enable automatically (`setEnabled(true)` + `subscribeToCapture()`) once permission is granted. Applies to both the toggle and the dedicated grant-permission button.

## Verification note
Mobile typecheck/lint isn't runnable locally here (`expo` missing). Verified via **Mobile Quality Checks** on this PR; holding merge until green.

Refs ABA-294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbRQ22TGCw6NdJwx4xEgsG)_