### PR TITLE
fix(mobile): show account currency in expenses total, not hardcoded USD

### DIFF
--- a/apps/mobile/app/(tabs)/expenses.tsx
+++ b/apps/mobile/app/(tabs)/expenses.tsx
@@ -20,6 +20,7 @@ import { useExpenseStore } from '@/stores/expenseStore';
 import { useIncomeStore } from '@/stores/incomeStore';
 import { hydrateTransactions } from '@/stores/hydrateTransactions';
 import { useAccountStore } from '@/stores/accountStore';
+import { useAuthStore } from '@/stores/authStore';
 import { useCategoryStore } from '@/stores/categoryStore';
 import { useExchangeRateStore } from '@/stores/exchangeRateStore';
 import { sumConverted } from '@/utils/total';
@@ -72,7 +73,11 @@ export default function ExpensesScreen() {
   );
   const rates = useExchangeRateStore((s) => s.rates);
   const baseCurrencyRaw = useExchangeRateStore((s) => s.baseCurrency);
-  const baseCurrency = baseCurrencyRaw || 'USD';
+  const userCurrency = useAuthStore((s) => s.user?.currencyCode);
+  // Fall back to the user's display currency (not a hardcoded USD) when the
+  // exchange-rate store hasn't populated its baseCurrency yet — e.g. a slow or
+  // failed rate fetch. Otherwise a PLN account's total shows a "$" label.
+  const baseCurrency = baseCurrencyRaw || userCurrency || 'USD';
   const filteredTotal = sumConverted(activeTab === 'expenses' ? expenses : incomes, baseCurrency, rates);
   const allCategories = useCategoryStore((s) => s.categories);
   const categories = allCategories.filter(

--- a/apps/mobile/src/stores/exchangeRateStore.ts
+++ b/apps/mobile/src/stores/exchangeRateStore.ts
@@ -69,9 +69,15 @@ export const useExchangeRateStore = create<ExchangeRateState>()(
 
     loadRates: async () => {
       set({ isLoading: true });
+      const useAuthStore = await getAuthStore();
+      const userCurrency = useAuthStore.getState().user?.currencyCode || 'USD';
+      // Set the base currency up front so the UI shows the correct currency
+      // label even if the rate fetch below fails (conversions then no-op, but a
+      // PLN account never falls back to a "$" label).
+      if (get().baseCurrency !== userCurrency) {
+        set({ baseCurrency: userCurrency });
+      }
       try {
-        const useAuthStore = await getAuthStore();
-        const userCurrency = useAuthStore.getState().user?.currencyCode || 'USD';
         const data = await api.getExchangeRates(userCurrency);
         set({
           rates: { ...data.rates, [userCurrency]: 1 },


### PR DESCRIPTION
The Expenses/Income filter-row total fell back to a hardcoded 'USD' label
whenever the exchange-rate store's baseCurrency was still empty (slow or
failed rate fetch), so a PLN account showed "$7,937.16" instead of "zł".

- expenses screen: fall back to user.currencyCode before 'USD', mirroring
  the pattern already used in NetProfitWidget/useCalendarData.
- exchangeRateStore.loadRates: set baseCurrency from user.currencyCode up
  front so the currency label is correct even if the rate fetch fails
  (conversions then no-op, but the label never wrongly shows USD).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E94WqaMas7bzFLFfmjaJ9v